### PR TITLE
When no database configuration is provided a php notice is send

### DIFF
--- a/Command/PhingCommand.php
+++ b/Command/PhingCommand.php
@@ -310,7 +310,7 @@ EOT;
     protected function checkConfiguration()
     {
         $parameters = $this->container->get('propel.configuration')->getParameters();
-        if (0 === count($parameters['datasources'])) {
+        if (!isset($parameters['datasources']) ||0 === count($parameters['datasources'])) {
             throw new \RuntimeException('Propel should be configured (no database configuration found).');
         }
     }


### PR DESCRIPTION
The non-existence of the "datasources" parameter is the responsible. 
