### PR TITLE
fixed Logger when it is null

### DIFF
--- a/Logger/PropelLogger.php
+++ b/Logger/PropelLogger.php
@@ -47,7 +47,9 @@ class PropelLogger
      */
     public function alert($message)
     {
-        $this->logger->alert($message);
+        if (null !== $this->logger) {
+            $this->logger->alert($message);
+        }
     }
 
     /**
@@ -57,7 +59,9 @@ class PropelLogger
      */
     public function crit($message)
     {
-        $this->logger->crit($message);
+        if (null !== $this->logger) {
+            $this->logger->crit($message);
+        }
     }
 
     /**
@@ -67,7 +71,9 @@ class PropelLogger
      */
     public function err($message)
     {
-        $this->logger->err($message);
+        if (null !== $this->logger) {
+            $this->logger->err($message);
+        }
     }
 
     /**
@@ -77,7 +83,9 @@ class PropelLogger
      */
     public function warning($message)
     {
-        $this->logger->warn($message);
+        if (null !== $this->logger) {
+            $this->logger->warn($message);
+        }
     }
 
     /**
@@ -87,7 +95,9 @@ class PropelLogger
      */
     public function notice($message)
     {
-        $this->logger->notice($message);
+        if (null !== $this->logger) {
+            $this->logger->notice($message);
+        }
     }
 
     /**
@@ -97,7 +107,9 @@ class PropelLogger
      */
     public function info($message)
     {
-        $this->logger->info($message);
+        if (null !== $this->logger) {
+            $this->logger->info($message);
+        }
     }
 
     /**
@@ -108,7 +120,9 @@ class PropelLogger
     public function debug($message)
     {
         $this->queries[] = $message;
-        $this->logger->debug($message);
+        if (null !== $this->logger) {
+            $this->logger->debug($message);
+        }
     }
 
     /**


### PR DESCRIPTION
The Logger passed to PropelLogger can be null. It was not taken into account.
