### PR TITLE
Make Exception message more usable (add bundle name)

### DIFF
--- a/Command/AbstractPropelCommand.php
+++ b/Command/AbstractPropelCommand.php
@@ -212,7 +212,8 @@ abstract class AbstractPropelCommand extends ContainerAwareCommand
                         $database['package'] = $prefix . '/' . str_replace('\\', '/', $database['namespace']);
                     } else {
                         throw new \RuntimeException(
-                            sprintf('Please define a `package` attribute or a `namespace` attribute for schema `%s`', $schema->getBaseName())
+                            sprintf('%s : Please define a `package` attribute or a `namespace` attribute for schema `%s`',
+                                $bundle->getName(), $schema->getBaseName())
                         );
                     }
 


### PR DESCRIPTION
if you have an error in your schema.xml, the message was not clear:

[RuntimeException]
  Please define a `package` attribute or a `namespace` attribute for schema `schema.xml`

I add bundle name in front of the message to help, to find the right `schema.xml`
