### PR TITLE
[EventListener] Fixed merging in MergeCollectionListener

### DIFF
--- a/Form/EventListener/MergeCollectionListener.php
+++ b/Form/EventListener/MergeCollectionListener.php
@@ -32,11 +32,11 @@ class MergeCollectionListener implements EventSubscriberInterface
             $collection->clear();
         } else {
             // merge $data into $collection
-            foreach ($collection as $model) {
-                if ($data->search($model) === false) {
-                    $collection->remove($model);
+            foreach ($collection as $i => $model) {
+                if (false === $key = $data->search($model)) {
+                    $collection->remove($i);
                 } else {
-                    $data->remove($model);
+                    $data->remove($key);
                 }
             }
 


### PR DESCRIPTION
I ended up with some "Warning: Illegal offset type in /var/www/dev/project/vendor/propel/runtime/lib/collection/PropelCollection.php line 287"

I fixed it by passing element's indexes to the remove() method instead of passing the elements themselves, which can't be handled by offsetUnset() and offsetExists() methods.
