### PR TITLE
[PropelParamConverter] add exclude option for Pk and fields, with tests a

### DIFF
--- a/Resources/doc/README.markdown
+++ b/Resources/doc/README.markdown
@@ -113,7 +113,7 @@ You can define _build properties_ by creating a `propel.ini` file in `app/config
 ``` ini
 # in app/config/propel.ini
 xxxx.xxxx.xxxx = XXXX
-```` 
+````
 
 But you can follow the Symfony2 way by adding build properties in `app/config/config.yml`:
 
@@ -333,3 +333,22 @@ public function myAction(Post $post)
 {
 }
 ```
+
+Exclude some parameters:
+
+You can exclude some attributes from being used by the converter:
+
+If you have a route like /my-route/{slug}/{name}/edit/{id}
+You can exclude "name" and "slug" by setting the option "exclude" :
+``` php
+<?php
+
+/**
+ * @ParamConverter("post", class="BlogBundle\Model\Post", options={"exclude"={"name", "slug"}})
+ */
+public function myAction(Post $post)
+{
+}
+```
+
+

--- a/Tests/Fixtures/Model/BookQuery.php
+++ b/Tests/Fixtures/Model/BookQuery.php
@@ -18,6 +18,7 @@ use Propel\PropelBundle\Tests\Fixtures\Model\om\BaseBookQuery;
 class BookQuery extends BaseBookQuery {
 
     private $bySlug = false;
+
     /**
      * fake for test
      */
@@ -45,9 +46,17 @@ class BookQuery extends BaseBookQuery {
     /**
      * fake for test
      */
+    public function filterByName($name = null, $comparison = null)
+    {
+        throw new \Exception('Test should never call this method');
+    }
+
+    /**
+     * fake for test
+     */
     public function findOne($con = null)
     {
-        if ($this->bySlug) {
+        if (true === $this->bySlug) {
             $book = new Book();
             $book->setId(1);
             $book->setName('My Book');

--- a/Tests/Request/ParamConverter/PropelParamConverterTest.php
+++ b/Tests/Request/ParamConverter/PropelParamConverterTest.php
@@ -45,7 +45,7 @@ class PropelParamConverterTest extends TestCase
     }
 
     /**
-     * @@expectedException Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     * @expectedException Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
     public function testParamConverterFindPkNotFound()
     {
@@ -66,7 +66,7 @@ class PropelParamConverterTest extends TestCase
     }
 
     /**
-     * @@expectedException Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+     * @expectedException Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
     public function testParamConverterFindSlugNotFound()
     {
@@ -76,8 +76,50 @@ class PropelParamConverterTest extends TestCase
         $paramConverter->apply($request, $configuration);
     }
 
+    public function testParamConverterFindBySlugNotByName()
+    {
+        $paramConverter = new PropelParamConverter();
+        $request = new Request(array(), array(), array('slug' => 'my-book', 'name' => 'foo', 'book' => null));
+        $configuration = new ParamConverter(array(
+                'class' => 'Propel\PropelBundle\Tests\Fixtures\Model\Book', 'name' => 'book',
+                'options' => array('exclude' => array('name'))));
+        $paramConverter->apply($request, $configuration);
+        $this->assertInstanceOf('Propel\PropelBundle\Tests\Fixtures\Model\Book',$request->attributes->get('book'),
+                'param "book" should be an instance of "Propel\PropelBundle\Tests\Fixtures\Model\Book"');
+    }
+
     /**
-     * @@expectedException LogicException
+     * @expectedException LogicException
+     */
+    public function testParamConverterFindByAllParamExcluded()
+    {
+        $paramConverter = new PropelParamConverter();
+        $request = new Request(array(), array(), array('slug' => 'my-book', 'name' => 'foo', 'book' => null));
+        $configuration = new ParamConverter(array(
+                'class' => 'Propel\PropelBundle\Tests\Fixtures\Model\Book', 'name' => 'book',
+                'options' => array('exclude' => array('name', 'slug'))));
+        $paramConverter->apply($request, $configuration);
+        $this->assertInstanceOf('Propel\PropelBundle\Tests\Fixtures\Model\Book',$request->attributes->get('book'),
+                'param "book" should be an instance of "Propel\PropelBundle\Tests\Fixtures\Model\Book"');
+    }
+
+    /**
+     * @expectedException LogicException
+     */
+    public function testParamConverterFindByIdExcluded()
+    {
+        $paramConverter = new PropelParamConverter();
+        $request = new Request(array(), array(), array('id' => '1234', 'book' => null));
+        $configuration = new ParamConverter(array(
+                'class' => 'Propel\PropelBundle\Tests\Fixtures\Model\Book', 'name' => 'book',
+                'options' => array('exclude' => array('id'))));
+        $paramConverter->apply($request, $configuration);
+        $this->assertInstanceOf('Propel\PropelBundle\Tests\Fixtures\Model\Book',$request->attributes->get('book'),
+                'param "book" should be an instance of "Propel\PropelBundle\Tests\Fixtures\Model\Book"');
+    }
+
+    /**
+     * @expectedException LogicException
      */
     public function testParamConverterFindLogicError()
     {


### PR DESCRIPTION
hi,

This add an exclude option that could be use to exclude request attributes from being use by the converter

If you have a route like /my-route/{slug}/{name}/edit/{id}
You can exclude "name" and "slug" by setting the option "exclude" :

``` php
<?php

/**
 * @ParamConverter("post", class="BlogBundle\Model\Post", options={"exclude"={"name", "slug"}})
 */
public function myAction(Post $post)
{
}
```
