### PR TITLE
Bug with Propel on windows, due to SplFileInfo

### DIFF
--- a/Command/AbstractPropelCommand.php
+++ b/Command/AbstractPropelCommand.php
@@ -255,7 +255,7 @@ abstract class AbstractPropelCommand extends ContainerAwareCommand
 
     private function transformToLogicalName(\SplFileInfo $schema, BundleInterface $bundle)
     {
-        $schemaPath = str_replace($bundle->getPath().'/Resources/config/', '', $schema->getPathname());
+        $schemaPath = str_replace($bundle->getPath().'/Resources/config/', '', str_replace(DIRECTORY_SEPARATOR, '/', $schema->getPathname()));
 
         return sprintf('@%s/Resources/config/%s', $bundle->getName(), $schemaPath);
     }


### PR DESCRIPTION
Hi there.

Just found a bug while trying to propel:build with Sf2 just after updated PropelBundle : SplFileInfo uses DIRECTORY_SEPARATOR, not / when using getPathname() - so it returns C:/wamp/www/SfPropelProject/src/Blah/XBundle/Resources/config\ <= that \ here is problematic.
I could also have replaced config/ with config' . DIRECTORY_SEPARATOR but I don't know if that'd work in all situations, so I choosed to use str_replace - tell me if it's no good.
