### PR TITLE
[2.0] Fixed bug in CLI environment

### DIFF
--- a/DependencyInjection/PropelExtension.php
+++ b/DependencyInjection/PropelExtension.php
@@ -68,15 +68,13 @@ class PropelExtension extends Extension
             $loader->load('converters.xml');
         }
 
-        if (0 === strncasecmp(PHP_SAPI, 'cli', 3)) {
-            if (isset($config['build_properties']) && is_array($config['build_properties'])) {
-                $buildProperties = $config['build_properties'];
-            } else {
-                $buildProperties = array();
-            }
-
-            $container->getDefinition('propel.build_properties')->setArguments(array($buildProperties));
+        if (isset($config['build_properties']) && is_array($config['build_properties'])) {
+            $buildProperties = $config['build_properties'];
+        } else {
+            $buildProperties = array();
         }
+
+        $container->getDefinition('propel.build_properties')->setArguments(array($buildProperties));
 
         if (!empty($config['dbal'])) {
             $this->dbalLoad($config['dbal'], $container);


### PR DESCRIPTION
If the cache is built out of CLI environment, the Symfony service `propel.build_properties` has no parameter.

And after, if I build classes `./app/console propel:build --classes`, the parameter in propel.build_properties is empty and my model is not built correctly.
