### PR TITLE
Fix fixtures ordering

### DIFF
--- a/Command/FixturesLoadCommand.php
+++ b/Command/FixturesLoadCommand.php
@@ -163,9 +163,7 @@ EOT
             return;
         }
 
-        $finder = new Finder();
-        $tmpdir = $this->getApplication()->getKernel()->getRootDir() . '/cache/propel';
-        $datas  = $finder->name('*.' . $type)->in($this->absoluteFixturesPath);
+        $datas = $this->getFixtureFiles($type);
 
         if (count(iterator_to_array($datas)) === 0) {
             return -1;
@@ -210,9 +208,8 @@ EOT
      */
     protected function loadSqlFixtures(InputInterface $input, OutputInterface $output)
     {
-        $finder = new Finder();
         $tmpdir = $this->getApplication()->getKernel()->getRootDir() . '/cache/propel';
-        $datas  = $finder->name('*.sql')->in($this->absoluteFixturesPath);
+        $datas  = $this->getFixtureFiles('sql');
 
         $this->prepareCache($tmpdir);
 
@@ -285,5 +282,22 @@ EOT
         }
 
         return true;
+    }
+
+    /**
+     * Returns the fixtures files to load.
+     *
+     * @param string $type  The extension of the files.
+     * @param string $in    The directory in which we search the files. If null,
+     *                      we'll use the absoluteFixturesPath property.
+     *
+     * @return \Iterator An iterator through the files.
+     */
+    protected function getFixtureFiles($type = 'sql', $in = null)
+    {
+        $finder = new Finder();
+        $finder->sortByName()->name('*.' . $type);
+
+        return $finder->in(null !== $in ? $in : $this->absoluteFixturesPath);
     }
 }

--- a/Tests/FixturesLoadCommandTest.php
+++ b/Tests/FixturesLoadCommandTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * This file is part of the PropelBundle package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
+namespace Tests\Command;
+
+use Symfony\Component\Filesystem\Filesystem;
+
+use Propel\PropelBundle\Tests\TestCase;
+use Propel\PropelBundle\Command\FixturesLoadCommand;
+
+/**
+ * @author Kévin Gomez <contact@kevingomez.fr>
+ */
+class FixturesLoadCommandTest extends TestCase
+{
+    protected $command;
+
+    public function setUp()
+    {
+        $this->command = new TestableFixturesLoadCommand('testable-command');
+
+        // let's create some dummy fixture files
+        $this->fixtures_dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'propel';
+        $this->fixtures_files = array(
+            '10_foo.yml', '20_bar.yml', '15_biz.yml', '18_boo.sql', '42_baz.sql'
+        );
+
+        $this->filesystem = new Filesystem();
+        $this->filesystem->mkdir($this->fixtures_dir);
+        foreach ($this->fixtures_files as $file)
+        {
+            $this->filesystem->touch($this->fixtures_dir . DIRECTORY_SEPARATOR . $file);
+        }
+    }
+
+    public function tearDown()
+    {
+        $this->filesystem->remove($this->fixtures_dir);
+    }
+
+    public function testOrderedFixturesFiles()
+    {
+        $this->assertEquals(
+            array('10_foo.yml', '15_biz.yml', '20_bar.yml',),
+            $this->cleanFixtureIterator($this->command->getFixtureFiles('yml', $this->fixtures_dir))
+        );
+
+        $this->assertEquals(
+            array('18_boo.sql', '42_baz.sql',),
+            $this->cleanFixtureIterator($this->command->getFixtureFiles('sql', $this->fixtures_dir))
+        );
+    }
+
+    protected function cleanFixtureIterator($file_iterator)
+    {
+        $tmp_dir = $this->fixtures_dir;
+
+        return array_map(function($file) use($tmp_dir) {
+            return str_replace($tmp_dir . DIRECTORY_SEPARATOR, '', $file);
+        }, array_keys(iterator_to_array($file_iterator)));
+    }
+}
+
+class TestableFixturesLoadCommand extends FixturesLoadCommand
+{
+    public function getFixtureFiles($type = 'sql', $in = null)
+    {
+        return parent::getFixtureFiles($type, $in);
+    }
+}


### PR DESCRIPTION
Hi,

The fixture loading task was not able to control the order of data loading (the file 50_foo.yml could be loaded before the 10_bar.yml file).
I tried to fix and test it. Let me know if I missed something :)
