### PR TITLE
Fix propel:reverse for non-mysql databases

### DIFF
--- a/Command/ReverseCommand.php
+++ b/Command/ReverseCommand.php
@@ -62,8 +62,8 @@ EOT
 
         $ret = $this->callPhing('reverse', array(
             'propel.project'            => $name,
+            'propel.database'           => $defaultConfig['adapter'],
             'propel.database.url'       => $defaultConfig['connection']['dsn'],
-            'propel.database.database'  => $defaultConfig['adapter'],
             'propel.database.user'      => $defaultConfig['connection']['user'],
             'propel.database.password'  => isset($defaultConfig['connection']['password']) ? $defaultConfig['connection']['password'] : '',
         ));


### PR DESCRIPTION
Set _propel.database_ parameter when calling phing _reverse_ task.
Otherwise it is set to _mysql_ by default, which obviously cause _invalid statement_ errors when querying database.

See #89 for more details.

Tested with MySql and Oracle.
