### PR TITLE
allow re-usage of DataLoader

### DIFF
--- a/DataFixtures/Loader/AbstractDataLoader.php
+++ b/DataFixtures/Loader/AbstractDataLoader.php
@@ -31,11 +31,12 @@ abstract class AbstractDataLoader extends AbstractDataHandler implements DataLoa
     /**
      * @var array
      */
-    private $deletedClasses = array();
+    protected $deletedClasses = array();
+
     /**
      * @var array
      */
-    private $object_references = array();
+    protected $object_references = array();
 
     /**
      * Transforms a file containing data in an array.
@@ -51,6 +52,7 @@ abstract class AbstractDataLoader extends AbstractDataHandler implements DataLoa
     public function load($files = array(), $connectionName)
     {
         $nbFiles = 0;
+        $this->deletedClasses = array();
 
         $this->loadMapBuilders($connectionName);
         $this->con = Propel::getConnection($connectionName);

--- a/DataFixtures/Loader/DataWiper.php
+++ b/DataFixtures/Loader/DataWiper.php
@@ -23,6 +23,7 @@ class DataWiper extends AbstractDataLoader
      */
     public function load($files = array(), $connectionName)
     {
+        $this->deletedClasses = array();
         $this->loadMapBuilders($connectionName);
 
         $this->con = \Propel::getConnection($connectionName);


### PR DESCRIPTION
When not creating new instances for each `load` call, the data is not loaded correctly.
