### PR TITLE
allow self reference in DataLoader

### DIFF
--- a/DataFixtures/Loader/AbstractDataLoader.php
+++ b/DataFixtures/Loader/AbstractDataLoader.php
@@ -167,6 +167,15 @@ abstract class AbstractDataLoader extends AbstractDataHandler implements DataLoa
 
                     // foreign key?
                     if ($isARealColumn) {
+                        // self referencing entry
+                        if ($column->isPrimaryKey() && null !== $value) {
+                            if (isset($this->object_references[$class.'_'.$value])) {
+                                $obj = $this->object_references[$class.'_'.$value];
+
+                                continue;
+                            }
+                        }
+
                         if ($column->isForeignKey() && null !== $value) {
                             $relatedTable = $this->dbMap->getTable($column->getRelatedTableName());
                             if (!isset($this->object_references[$relatedTable->getClassname().'_'.$value])) {

--- a/Tests/DataFixtures/Loader/YamlDataLoaderTest.php
+++ b/Tests/DataFixtures/Loader/YamlDataLoaderTest.php
@@ -108,4 +108,31 @@ YAML;
         $this->assertCount(1, $bookAuthors);
         $this->assertInstanceOf('Propel\PropelBundle\Tests\Fixtures\DataFixtures\Loader\YamlManyToManyBookAuthor', $bookAuthors[0]);
     }
+
+    public function testLoadSelfReferencing()
+    {
+        $fixtures = <<<YAML
+Propel\PropelBundle\Tests\Fixtures\DataFixtures\Loader\BookAuthor:
+    BookAuthor_1:
+        id: '1'
+        name: 'to be announced'
+    BookAuthor_2:
+        id: BookAuthor_1
+        name: 'A famous one'
+
+YAML;
+        $filename = $this->getTempFile($fixtures);
+
+        $loader = new YamlDataLoader(__DIR__.'/../../Fixtures/DataFixtures/Loader');
+        $loader->load(array($filename), 'default');
+
+        $books = \Propel\PropelBundle\Tests\Fixtures\DataFixtures\Loader\BookPeer::doSelect(new \Criteria(), $this->con);
+        $this->assertCount(0, $books);
+
+        $authors = \Propel\PropelBundle\Tests\Fixtures\DataFixtures\Loader\BookAuthorPeer::doSelect(new \Criteria(), $this->con);
+        $this->assertCount(1, $authors);
+
+        $author = $authors[0];
+        $this->assertEquals('A famous one', $author->getName());
+    }
 }


### PR DESCRIPTION
This allows to reference on previous entries of the same model, thus issuing on `UPDATE` rather than an `INSERT` on the object. This is helpful, if you need to load fixtures with `VersionableBehavior` attached and loading multiple versions.

An example YAML fixtures file:

``` yaml
Acme\Bundle\BlogBundle\Model\Post:
    Post:
        name: "A very interesting one"
        content: "Content with a typoe."
        version: 1
        version_created: 2012-02-29 12:03:23

    Post_V2:
        id: Post
        name: "A very interesting one"
        content: "Content without the typo."
        version: 2
        version_created: 2012-02-29 12:07:12

```

This would create _one_ `Post` entry, but with _two_ `PostVersion` of it.
