### PR TITLE
Add phing_path directly to include path to make it work with composer and pear package

### DIFF
--- a/PropelBundle.php
+++ b/PropelBundle.php
@@ -28,7 +28,10 @@ class PropelBundle extends Bundle
         require_once $this->container->getParameter('propel.path').'/runtime/lib/Propel.php';
 
         if (0 === strncasecmp(PHP_SAPI, 'cli', 3)) {
-            set_include_path($this->container->getParameter('kernel.root_dir').'/..'.PATH_SEPARATOR.$this->container->getParameter('propel.phing_path').'/classes'.PATH_SEPARATOR.get_include_path());
+            set_include_path($this->container->getParameter('kernel.root_dir').'/..'.PATH_SEPARATOR.
+                             $this->container->getParameter('propel.phing_path').PATH_SEPARATOR.
+                             $this->container->getParameter('propel.phing_path').'/classes'.PATH_SEPARATOR.
+                             get_include_path());
         }
 
         if (!\Propel::isInit()) {


### PR DESCRIPTION
This will help working with composer and pear package for phing instead of Xosofox/phing copy

this could be use with this in conf:

```
phing_path: "%kernel.root_dir%/../vendor/pear-phing"
```

and this in composer.json

```
"repositories": [
       {
           "type": "pear",
           "url": "http://pear.phing.info"
       }
   ],
   "require": {
       "pear-phing/phing": "2.4.9"
   }
}
```
