### PR TITLE
silently ignore "misconfigured" slaves

### DIFF
--- a/DependencyInjection/PropelExtension.php
+++ b/DependencyInjection/PropelExtension.php
@@ -107,7 +107,7 @@ class PropelExtension extends Extension
 
             if (!empty($conf['slaves'])) {
                 // silently ignore misconfigured slaves
-                // this let's us have slaves in prod but not in dev environments by only altering parameters.inc
+                // this lets us have slaves in prod but not in dev environments by only altering parameters.inc
                 foreach ($conf['slaves'] as $slaveKey => $slaveData) {
                     if (empty($slaveData['user']) || empty($slaveData['dsn'])) {
                         unset($conf['slaves'][$slaveKey]);


### PR DESCRIPTION
I know this might be controversial, but a feature we would benefit from in our setup.

Allowing propel to silently ignore "misconfigured" slaves.

This is useful when you have your config_xxx files in scm and different parameters.inc files on production/staging/testing/development servers

We have testing servers where the number of slaves is much lower than on production servers, but test in both "prod" and "dev" mode on the test server.

Hens loading the different config files would break, if we could not ignore slaves where their user or dsn is empty.
