### PR TITLE
fix load fixtures for one-to-many relation with FQCN

### DIFF
--- a/DataFixtures/Loader/AbstractDataLoader.php
+++ b/DataFixtures/Loader/AbstractDataLoader.php
@@ -124,7 +124,7 @@ abstract class AbstractDataLoader extends AbstractDataHandler implements DataLoa
         }
 
         foreach ($data as $class => $datas) {
-            $class        = trim($class);
+            $class = trim($class);
             if ('\\' == $class[0]) {
                 $class = substr($class, 1);
             }

--- a/DataFixtures/Loader/AbstractDataLoader.php
+++ b/DataFixtures/Loader/AbstractDataLoader.php
@@ -125,6 +125,9 @@ abstract class AbstractDataLoader extends AbstractDataHandler implements DataLoa
 
         foreach ($data as $class => $datas) {
             $class        = trim($class);
+            if ('\\' == $class[0]) {
+                $class = substr($class, 1);
+            }
             $tableMap     = $this->dbMap->getTable(constant(constant($class.'::PEER').'::TABLE_NAME'));
             $column_names = call_user_func_array(array(constant($class.'::PEER'), 'getFieldNames'), array(BasePeer::TYPE_FIELDNAME));
 


### PR DESCRIPTION
Hi,

This fix an issue with load fixtures.

When classname are FQCN in the fixture like in doc example. it fail to find related object.

with this fix it work with both FQCN or QCN
