### PR TITLE
Added faker support

### DIFF
--- a/Command/FixturesLoadCommand.php
+++ b/Command/FixturesLoadCommand.php
@@ -181,7 +181,7 @@ EOT
         list($name, $defaultConfig) = $this->getConnection($input, $output);
 
         if ('yml' === $type) {
-            $loader = new YamlDataLoader($this->getApplication()->getKernel()->getRootDir());
+            $loader = new YamlDataLoader($this->getApplication()->getKernel()->getRootDir(), $this->getContainer());
         } elseif ('xml' === $type) {
             $loader = new XmlDataLoader($this->getApplication()->getKernel()->getRootDir());
         } else {

--- a/Resources/doc/README.markdown
+++ b/Resources/doc/README.markdown
@@ -298,6 +298,19 @@ is a timestamp.
 Once done, you will be able to load this files by using the `propel:fixtures:load` command.
 
 
+#### Use Faker in YAML fixtures ####
+
+If you use [Faker](https://github.com/fzaninotto/Faker) with its [Symfony2 integration](https://github.com/willdurand/BazingaFakerBundle),
+then the PropelBundle offers a facility to use the Faker generator in your YAML files.
+
+``` yml
+My\Bundle\Model\MyClass:
+    mc1:
+        name: "Awesome Feature"
+        description: <?php $faker('text', 500); ?>
+```
+
+
 ### Graphviz ###
 
 You can generate **Graphviz** file for your project by using the following command line:

--- a/Tests/DataFixtures/TestCase.php
+++ b/Tests/DataFixtures/TestCase.php
@@ -40,6 +40,7 @@ class TestCase extends BaseTestCase
     <table name="book">
         <column name="id" type="integer" primaryKey="true" />
         <column name="name" type="varchar" size="255" />
+        <column name="description" type="varchar" />
         <column name="author_id" type="integer" required="false" defaultValue="null" />
 
         <foreign-key foreignTable="book_author" onDelete="RESTRICT" onUpdate="CASCADE">

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     "propel/propel1": "1.6.*"
   },
   "require-dev": {
-    "sensio/framework-extra-bundle": "dev-master"
+    "sensio/framework-extra-bundle": "dev-master",
+    "fzaninotto/faker": "dev-master"
   },
   "autoload": {
     "psr-0": { "Propel\\PropelBundle": "" }


### PR DESCRIPTION
Use case: most of the time, you generate to populate your database at development time. But you will probably have to manage few columns with real data. Two options:
- configure Faker which takes a lot of time;
- use fixtures files which is painful because you need to be inventive.

Then, why not having both? This PR adds a new PHP variable in YAML files to use the Faker Generator provided by Faker, and the FakerBundle.

``` yaml
A\Class:
  a1:
    title: <?php $faker('word', 3); ?>
    location: Paris, France # Real data to use in a geocoding process for instance
```
