### PR TITLE
[WIP] [ParamConverter] add 'with' option to hydrate related object

### DIFF
--- a/Request/ParamConverter/PropelParamConverter.php
+++ b/Request/ParamConverter/PropelParamConverter.php
@@ -122,6 +122,12 @@ class PropelParamConverter implements ParamConverterInterface
         return false;
     }
 
+    /**
+     * Try to find the object with the id
+     *
+     * @param string $classQuery the query class
+     * @param Request $request
+     */
     protected function findPk($classQuery, Request $request)
     {
         if (in_array($this->pk, $this->exclude) || !$request->attributes->has($this->pk)) {
@@ -131,6 +137,13 @@ class PropelParamConverter implements ParamConverterInterface
         return $this->getQuery($classQuery)->findPk($request->attributes->get($this->pk));
     }
 
+    /**
+     * Try to find the object with all params from the $request
+     *
+     * @param string $classQuery
+     * @param Request $request the query class
+     * @param array $exclude an array of param to exclude from the filter
+     */
     protected function findOneBy($classQuery, Request $request)
     {
         $query = $this->getQuery($classQuery);
@@ -151,6 +164,12 @@ class PropelParamConverter implements ParamConverterInterface
         return $query->findOne();
     }
 
+    /**
+     * Init the query class with optional joinWith
+     *
+     * @param string $classQuery
+     * @throws \Exception
+     */
     protected function getQuery($classQuery)
     {
         $query = $classQuery::create();
@@ -172,6 +191,12 @@ class PropelParamConverter implements ParamConverterInterface
         return $query;
     }
 
+    /**
+     * Return the valid join Criteria base on the with parameter
+     *
+     * @param array $with
+     * @throws \Exception
+     */
     protected function getValidJoin($with)
     {
         switch (str_replace(array('_', 'JOIN'),'', strtoupper($with[1]))) {

--- a/Resources/doc/param_converter.markdown
+++ b/Resources/doc/param_converter.markdown
@@ -64,4 +64,39 @@ public function myAction(Post $post, $author)
 }
 ```
 
+#### Hydrate related object ####
+
+You could hydrate related object with the "with" option:
+
+``` php
+<?php
+
+/**
+ * @ParamConverter("post", class="BlogBundle\Model\Post", options={"with"={"Comments"}})
+ */
+public function myAction(Post $post)
+{
+}
+```
+
+You can set multiple with ```"with"={"Comments", "Author", "RelatedPosts"}```.
+
+The default join is an "inner join" but you can configure it to be a left join, right join or inner join :
+
+``` php
+<?php
+
+/**
+ * @ParamConverter("post", class="BlogBundle\Model\Post", options={"with"={ {"Comments", "left join" } }})
+ */
+public function myAction(Post $post)
+{
+}
+```
+Accepted parmeters for join :
+
+  left, LEFT, left join, LEFT JOIN, left_join, LEFT_JOIN
+  right, RIGHT, right join, RIGHT JOIN, right_join, RIGHT_JOIN
+  inner, INNER, inner join, INNER JOIN, inner_join, INNER_JOIN
+
 [Back to index](index.markdown)

--- a/Tests/Request/ParamConverter/PropelParamConverterTest.php
+++ b/Tests/Request/ParamConverter/PropelParamConverterTest.php
@@ -12,11 +12,21 @@ use Propel\PropelBundle\Tests\TestCase;
 class PropelParamConverterTest extends TestCase
 {
 
+    protected $con;
+
     public function setUp()
     {
         parent::setUp();
         if (!interface_exists('Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface')) {
             $this->markTestSkipped('SensioFrameworkExtraBundle is not available.');
+        }
+    }
+
+    public function tearDown()
+    {
+        \Propel::enableInstancePooling();
+        if ($this->con) {
+            $this->con->useDebug(false);
         }
     }
 
@@ -177,5 +187,118 @@ class PropelParamConverterTest extends TestCase
         $paramConverter->apply($request, $configuration);
         $this->assertInstanceOf('Propel\PropelBundle\Tests\Fixtures\Model\Book',$request->attributes->get('book'),
                 'param "book" should be an instance of "Propel\PropelBundle\Tests\Fixtures\Model\Book"');
+    }
+
+    public function testParamConvertWithOptionWith()
+    {
+        $this->loadFixture();
+        \Propel::disableInstancePooling();
+
+        $paramConverter = new PropelParamConverter();
+        $request = new Request(array(), array(), array('id' => 1, 'book' => null));
+        $configuration = new ParamConverter(array(
+                'class' => 'Propel\PropelBundle\Tests\Request\ParamConverter\MyBook',
+                'name' => 'book',
+                'options' => array(
+                        'with' => 'MyAuthor'
+                        )
+                ));
+
+        $nb = $this->con->getQueryCount();
+        $paramConverter->apply($request, $configuration);
+
+        $book = $request->attributes->get('book');
+        $this->assertInstanceOf('Propel\PropelBundle\Tests\Request\ParamConverter\MyBook', $book,
+                'param "book" should be an instance of "Propel\PropelBundle\Tests\Request\ParamConverter\MyBook"');
+
+        $this->assertEquals($nb +1, $this->con->getQueryCount(), 'only one query to get the book');
+
+        $this->assertInstanceOf('Propel\PropelBundle\Tests\Request\ParamConverter\MyAuthor', $book->getMyAuthor(),
+                'param "book" should be an instance of "Propel\PropelBundle\Tests\Request\ParamConverter\MyAuthor"');
+
+        $this->assertEquals($nb +1, $this->con->getQueryCount(), 'no new query to get the author');
+        \Propel::enableInstancePooling();
+    }
+
+    public function testParamConvertWithOptionWithLeftJoin()
+    {
+        $this->loadFixture();
+        \Propel::disableInstancePooling();
+
+        $paramConverter = new PropelParamConverter();
+        $request = new Request(array(), array(), array('param1' => 10, 'author' => null));
+        $configuration = new ParamConverter(array(
+                'class' => 'Propel\PropelBundle\Tests\Request\ParamConverter\MyAuthor',
+                'name' => 'author',
+                'options' => array(
+                        'with' => array(array('MyBook', 'left join')),
+                        'mapping' => array('param1' => 'id'),
+                        )
+                ));
+
+        $nb = $this->con->getQueryCount();
+        $paramConverter->apply($request, $configuration);
+
+        $author = $request->attributes->get('author');
+        $this->assertInstanceOf('Propel\PropelBundle\Tests\Request\ParamConverter\MyAuthor', $author,
+                'param "author" should be an instance of "Propel\PropelBundle\Tests\Request\ParamConverter\MyAuthor"');
+
+        $this->assertEquals($nb +1, $this->con->getQueryCount(), 'only one query to get the book');
+
+        $books = $author->getMyBooks();
+        $this->assertInstanceOf('PropelObjectCollection', $books);
+        $this->assertCount(2, $books, 'Author should have two books');
+
+        $this->assertEquals($nb +1, $this->con->getQueryCount(), 'no new query to get the books');
+    }
+
+    protected function loadFixture()
+    {
+        $this->loadPropelQuickBuilder();
+
+        $schema = <<<XML
+<database name="default" package="vendor.bundles.Propel.PropelBundle.Tests.Request.DataFixtures.Loader" namespace="Propel\PropelBundle\Tests\Request\ParamConverter" defaultIdMethod="native">
+    <table name="my_book">
+        <column name="id" type="integer" primaryKey="true" />
+        <column name="name" type="varchar" size="255" />
+        <column name="my_author_id" type="integer" />
+        <foreign-key foreignTable="my_author" onDelete="CASCADE" onUpdate="CASCADE">
+            <reference local="my_author_id" foreign="id" />
+        </foreign-key>
+    </table>
+
+    <table name="my_author">
+        <column name="id" type="integer" primaryKey="true" />
+        <column name="name" type="varchar" size="255" />
+    </table>
+
+</database>
+XML;
+        $builder = new \PropelQuickBuilder();
+        $builder->setSchema($schema);
+        if (class_exists('Propel\PropelBundle\Tests\Request\ParamConverter\MyAuthor')) {
+            $builder->setClassTargets(array());
+        }
+        $this->con = $builder->build();
+        $this->con->useDebug(true);
+
+        MyBookQuery::create()->deleteAll($this->con);
+        MyAuthorQuery::create()->deleteAll($this->con);
+
+        $author = new MyAuthor();
+        $author->setId(10);
+        $author->setName('Will');
+
+        $book = new MyBook();
+        $book->setId(1);
+        $book->setName('PropelBook');
+        $book->setMyAuthor($author);
+
+        $book2 = new MyBook();
+        $book2->setId(2);
+        $book2->setName('sf2lBook');
+        $book2->setMyAuthor($author);
+
+        $author->save($this->con);
     }
 }


### PR DESCRIPTION
Hi,

This add a new option `with` for the PropelParamConverter

This allow to hydrate related object simply by adding `option={"with": {"book"}}`

``` php
<?php
/**
 * @ParamConverter("post", class="BlogBundle\Model\Post", options={"with"={ {"comments", "left join"} }})
 */
public function myAction(Post $post) { }
```

and when sensio/SensioFrameworkExtraBundle#119 is accepted :

``` php
<?php
/**
 * @ParamConverter("post", options={"with"={"comments"}})
 */
public function myAction(Post $post) { }
```
