### PR TITLE
Enable PropelParamConverter to find on ->getName()

### DIFF
--- a/Request/ParamConverter/PropelParamConverter.php
+++ b/Request/ParamConverter/PropelParamConverter.php
@@ -27,7 +27,7 @@ class PropelParamConverter implements ParamConverterInterface
         $exclude = isset($options['exclude'])? $options['exclude'] : array();
 
         // find by Pk
-        if (in_array('id', $exclude) || false === $object = $this->findPk($classQuery, $request)) {
+        if (in_array('id', $exclude) || false === $object = $this->findPk($classQuery, $request, $configuration->getName())) {
             // find by criteria
             if (false === $object = $this->findOneBy($classQuery, $request, $exclude)) {
                 throw new \LogicException('Unable to guess how to get a Propel object from the request information.');
@@ -41,13 +41,17 @@ class PropelParamConverter implements ParamConverterInterface
         $request->attributes->set($configuration->getName(), $object);
     }
 
-    protected function findPk($classQuery, Request $request)
+    protected function findPk($classQuery, Request $request, $pk)
     {
-        if (!$request->attributes->has('id')) {
+        if (!$request->attributes->has($pk) || '' == $request->attributes->get($pk)) {
+            $pk = 'id';
+        }
+
+        if (!$request->attributes->has($pk)) {
             return false;
         }
 
-        return $classQuery::create()->findPk($request->attributes->get('id'));
+        return $classQuery::create()->findPk($request->attributes->get($pk));
     }
 
     protected function findOneBy($classQuery, Request $request, $exclude)

--- a/Tests/Request/ParamConverter/PropelParamConverterTest.php
+++ b/Tests/Request/ParamConverter/PropelParamConverterTest.php
@@ -55,6 +55,16 @@ class PropelParamConverterTest extends TestCase
         $paramConverter->apply($request, $configuration);
     }
 
+    public function testFindPkOnBook()
+    {
+        $paramConverter = new PropelParamConverter();
+        $request = new Request(array(), array(), array('book' => 1));
+        $configuration = new ParamConverter(array('class' => 'Propel\PropelBundle\Tests\Fixtures\Model\Book', 'name' => 'book'));
+        $paramConverter->apply($request, $configuration);
+        $this->assertInstanceOf('Propel\PropelBundle\Tests\Fixtures\Model\Book',$request->attributes->get('book'),
+                        'param "book" should be an instance of "Propel\PropelBundle\Tests\Fixtures\Model\Book"');
+    }
+
     public function testParamConverterFindSlug()
     {
         $paramConverter = new PropelParamConverter();


### PR DESCRIPTION
This make easiest Param conversion for esi

``` php
<?php

/**
  * @ParamConverter("book", class="MyCoreBundle:Model:Core:Book")
  */
    public function renderAction(Book $book)
    {
        return $this->render('....', array(
            'book' => $book,
        ));
    }
```
