### PR TITLE
Feature camel cased params

### DIFF
--- a/Request/ParamConverter/PropelParamConverter.php
+++ b/Request/ParamConverter/PropelParamConverter.php
@@ -2,6 +2,7 @@
 
 namespace Propel\PropelBundle\Request\ParamConverter;
 
+use Propel\PropelBundle\Util\PropelInflector;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -57,7 +58,7 @@ class PropelParamConverter implements ParamConverterInterface
         foreach ($request->attributes->all() as $key => $value) {
             if (!in_array($key, $exclude)) {
                 try {
-                    $query->{'filterBy' . ucfirst($key)}($value);
+                    $query->{'filterBy' . PropelInflector::camelize($key)}($value);
                     $hasCriteria = true;
                 } catch (\PropelException $e) { }
             }

--- a/Tests/Fixtures/Model/BookQuery.php
+++ b/Tests/Fixtures/Model/BookQuery.php
@@ -18,6 +18,7 @@ use Propel\PropelBundle\Tests\Fixtures\Model\om\BaseBookQuery;
 class BookQuery extends BaseBookQuery {
 
     private $bySlug = false;
+    private $byAuthorSlug = false;
 
     /**
      * fake for test
@@ -32,6 +33,18 @@ class BookQuery extends BaseBookQuery {
         }
 
         return null;
+    }
+
+    /**
+     * fake for test
+     */
+    public function filterByAuthorSlug($slug = null, $comparison = null)
+    {
+        if ('my-author' === $slug) {
+            $this->byAuthorSlug = true;
+        }
+
+        return $this;
     }
 
     /**
@@ -64,6 +77,13 @@ class BookQuery extends BaseBookQuery {
             $book->setId(1);
             $book->setName('My Book');
             $book->setSlug('my-book');
+
+            return $book;
+        } else if (true === $this->byAuthorSlug) {
+            $book = new Book();
+            $book->setId(2);
+            $book->setName('My Kewl Book');
+            $book->setSlug('my-kewl-book');
 
             return $book;
         }

--- a/Tests/Request/ParamConverter/PropelParamConverterTest.php
+++ b/Tests/Request/ParamConverter/PropelParamConverterTest.php
@@ -65,6 +65,17 @@ class PropelParamConverterTest extends TestCase
                         'param "book" should be an instance of "Propel\PropelBundle\Tests\Fixtures\Model\Book"');
     }
 
+    public function testParamConverterFindCamelCasedSlug()
+    {
+        $paramConverter = new PropelParamConverter();
+        $request = new Request(array(), array(), array('author_slug' => 'my-author', 'slug' => 'my-kewl-book', 'book' => null));
+        $configuration = new ParamConverter(array('class' => 'Propel\PropelBundle\Tests\Fixtures\Model\Book', 'name' => 'book'));
+
+        $paramConverter->apply($request, $configuration);
+        $this->assertInstanceOf('Propel\PropelBundle\Tests\Fixtures\Model\Book',$request->attributes->get('book'),
+                        'param "book" should be an instance of "Propel\PropelBundle\Tests\Fixtures\Model\Book"');
+    }
+
     /**
      * @expectedException Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */


### PR DESCRIPTION
Currently, parameters like "author_slug" are translated by the param
converter to a "->filterByAuthor_slug()" call. I changed this behavior
and they are now translated to "->filterByAuthorSlug()".
