### PR TITLE
propel:form:generate creates an incompatible parameter type

### DIFF
--- a/Resources/skeleton/FormType.php
+++ b/Resources/skeleton/FormType.php
@@ -3,14 +3,14 @@
 namespace ##NAMESPACE##;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Form\FormBuilderInterface;
 
 class ##CLASS## extends AbstractType
 {
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilder $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options)
     {##BUILD_CODE##
     }
 


### PR DESCRIPTION
Fatal error: Declaration of Company\ProjectBundle\Form\Type\UserType::buildForm() must be compatible with that of Symfony\Component\Form\FormTypeInterface::buildForm() in ...
