### PR TITLE
Invoking propel:database:create throws a PDO connection error

### DIFF
--- a/Command/DatabaseCreateCommand.php
+++ b/Command/DatabaseCreateCommand.php
@@ -82,8 +82,8 @@ class DatabaseCreateCommand extends AbstractCommand
         $dbName = $this->parseDbName($config['connection']['dsn']);
 
         $config['connection']['dsn'] = preg_replace(
-            '#dbname='.$dbName.'#',
-            'dbname='.strtolower($config['adapter']),
+            '#dbname='.$dbName.';#',
+            '',
             $config['connection']['dsn']
         );
 


### PR DESCRIPTION
At least the MySQL PDO must be connected without the dbname in its dsn because the db being created does not exist yet.

Tested MySQL Server version 5.5.21.
