### PR TITLE
add connection option for commands: build, sql:build, migration:generate-diff

### DIFF
--- a/Command/AbstractCommand.php
+++ b/Command/AbstractCommand.php
@@ -61,6 +61,12 @@ abstract class AbstractCommand extends ContainerAwareCommand
     private $alreadyWroteConnection = false;
 
     /**
+     *
+     * @var InputInterface
+     */
+    protected $input;
+
+    /**
      * Return the package prefix for a given bundle.
      *
      * @param Bundle $bundle
@@ -89,6 +95,8 @@ abstract class AbstractCommand extends ContainerAwareCommand
     protected function initialize(InputInterface $input, OutputInterface $output)
     {
         parent::initialize($input, $output);
+
+        $this->input = $input;
 
         $this->checkConfiguration();
 
@@ -225,6 +233,13 @@ abstract class AbstractCommand extends ContainerAwareCommand
                     sprintf('%s : Please define a `package` attribute or a `namespace` attribute for schema `%s`',
                         $bundle->getName(), $finalSchema->getBaseName())
                 );
+            }
+
+            if ($this->input && $this->input->hasOption('connection') && $this->input->getOption('connection')
+                && $database['name'] != $this->input->getOption('connection')) {
+                //we skip this schema because the connection name doesn't match the input value
+                $filesystem->remove($file);
+                continue;
             }
 
             foreach ($database->table as $table) {

--- a/Command/AbstractCommand.php
+++ b/Command/AbstractCommand.php
@@ -238,6 +238,7 @@ abstract class AbstractCommand extends ContainerAwareCommand
             if ($this->input && $this->input->hasOption('connection') && $this->input->getOption('connection')
                 && $database['name'] != $this->input->getOption('connection')) {
                 //we skip this schema because the connection name doesn't match the input value
+                unset($this->tempSchemas[$tempSchema]);
                 $filesystem->remove($file);
                 continue;
             }

--- a/Command/BuildCommand.php
+++ b/Command/BuildCommand.php
@@ -14,6 +14,7 @@ use Propel\PropelBundle\Command\AbstractCommand;
 use Propel\PropelBundle\Command\ModelBuildCommand;
 use Propel\PropelBundle\Command\SqlBuildCommand;
 
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -51,26 +52,31 @@ class BuildCommand extends AbstractCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         if (!$input->getOption('sql')) {
-            $modelCommand = new ModelBuildCommand();
-            $modelCommand->setApplication($this->getApplication());
-            $modelCommand->execute($input, $output);
+            $in = new ArrayInput(array(
+                    'command'        => 'propel:model:build',
+                    '--connection'   => $input->getOption('connection')
+            ));
+            $modelCommand = $this->getApplication()->find('propel:model:build');
+            $res = $modelCommand->run($in, $output);
         }
 
         if (!$input->getOption('classes')) {
-            $sqlCommand = new SqlBuildCommand();
-            $sqlCommand->setApplication($this->getApplication());
-            $sqlCommand->execute($input, $output);
+            $in = new ArrayInput(array(
+                    'command'        => 'propel:build:sql',
+                    '--connection'   => $input->getOption('connection'),
+            ));
+            $sqlCommand = $this->getApplication()->find('propel:sql:build');
+            $sqlCommand->run($in, $output);
         }
 
         if ($input->getOption('insert-sql')) {
-            $insertCommand = new SqlInsertCommand();
-            $insertCommand->setApplication($this->getApplication());
-
-            // By-pass the '--force' required option
-            $this->addOption('force', '', InputOption::VALUE_NONE, '');
-            $input->setOption('force', true);
-
-            $insertCommand->execute($input, $output);
+            $in = new ArrayInput(array(
+                    'command'        => 'propel:sql:insert',
+                    '--connection'   => $input->getOption('connection'),
+                    '--force'        => true,
+            ));
+            $insertCommand = $this->getApplication()->find('propel:sql:insert');
+            $insertCommand->run($in, $output);
         }
     }
 }

--- a/Command/MigrationGenerateDiffCommand.php
+++ b/Command/MigrationGenerateDiffCommand.php
@@ -12,6 +12,7 @@ namespace Propel\PropelBundle\Command;
 
 use Propel\PropelBundle\Command\AbstractCommand;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -28,6 +29,7 @@ class MigrationGenerateDiffCommand extends AbstractCommand
     {
         $this
             ->setDescription('Generates SQL diff between the XML schemas and the current database structure')
+            ->addOption('connection', null, InputOption::VALUE_OPTIONAL, 'Set this parameter to define a connection to use')
             ->setHelp(<<<EOT
 The <info>propel:migration:generate-diff</info> command compares the current database structure and the available schemas. If there is a difference, it creates a migration file.
 

--- a/Command/MigrationMigrateCommand.php
+++ b/Command/MigrationMigrateCommand.php
@@ -11,10 +11,9 @@
 namespace Propel\PropelBundle\Command;
 
 use Propel\PropelBundle\Command\AbstractCommand;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Output\Output;
 
 /**
  * MigrationMigrateCommand.

--- a/Command/ModelBuildCommand.php
+++ b/Command/ModelBuildCommand.php
@@ -13,6 +13,7 @@ namespace Propel\PropelBundle\Command;
 use Propel\PropelBundle\Command\AbstractCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -31,6 +32,7 @@ class ModelBuildCommand extends AbstractCommand
         $this
             ->setDescription('Build the Propel Object Model classes based on XML schemas')
             ->addArgument('bundle', InputArgument::OPTIONAL, 'The bundle to generate model classes from')
+            ->addOption('connection', null, InputOption::VALUE_OPTIONAL, 'Set this parameter to define a connection to use')
             ->setHelp(<<<EOT
 The <info>%command.name%</info> command builds the Propel runtime model classes (ActiveRecord, Query, Peer, and TableMap classes) based on the XML schemas defined in all Bundles.
 

--- a/Command/SqlBuildCommand.php
+++ b/Command/SqlBuildCommand.php
@@ -11,6 +11,7 @@
 namespace Propel\PropelBundle\Command;
 
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Filesystem\Filesystem;
@@ -39,6 +40,7 @@ The <info>%command.name%</info> command builds the SQL table generation code bas
   <info>php %command.full_name%</info>
 EOT
             )
+            ->addOption('connection', null, InputOption::VALUE_OPTIONAL, 'Set this parameter to define a connection to use')
             ->setName('propel:sql:build')
         ;
     }

--- a/Resources/doc/commands.markdown
+++ b/Resources/doc/commands.markdown
@@ -49,7 +49,9 @@ It will write files in `app/propel/graph/`.
 
 Generates SQL diff between the XML schemas and the current database structure:
 
-    > php app/console propel:migration:generate-diff
+    > php app/console propel:migration:generate-diff [--connection[=""]]
+
+As usual, `--connection` allows to specify a connection.
 
 Executes the migrations:
 

--- a/Resources/doc/index.markdown
+++ b/Resources/doc/index.markdown
@@ -78,11 +78,11 @@ You are almost ready, the next steps are:
 
 Now, you can build your model classes, and SQL by running the following command:
 
-    > php app/console propel:build [--classes] [--sql] [--insert-sql]
+    > php app/console propel:build [--classes] [--sql] [--insert-sql] [--connection[=""]]
 
 To insert SQL statements, use the `propel:sql:insert` command:
 
-    > php app/console propel:sql:insert [--force]
+    > php app/console propel:sql:insert [--force] [--connection[=""]]
 
 Note that the `--force` option is needed to actually execute the SQL statements.
 


### PR DESCRIPTION
Hi,

This is a work in progress, it refactor Propel Hub command #91 and add connection option for those commands #138 :
- propel:build
- propel:migration:generate-diff
- propel:sql:build
