### PR TITLE
Fix: using the "with" option in ParamConverters triggered a notice

### DIFF
--- a/Request/ParamConverter/PropelParamConverter.php
+++ b/Request/ParamConverter/PropelParamConverter.php
@@ -190,7 +190,8 @@ class PropelParamConverter implements ParamConverterInterface
         if (!$this->hasWith) {
             return $query->findOne();
         } else {
-            return reset($query->find());
+            $results = $query->find();
+            return reset($results);
         }
     }
 


### PR DESCRIPTION
The following notice was triggered:

```
Runtime Notice: Only variables should be passed by reference in
/home/vagrant/www/project/vendor/propel/propel-bundle/Propel/PropelBundle/Request/ParamConverter/PropelParamConverter.php
line 193
```
