### PR TITLE
[Form] Allow setting custom message, adapt to sf2.1 API

### DIFF
--- a/Validator/Constraints/UniqueObject.php
+++ b/Validator/Constraints/UniqueObject.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * This file is part of the PropelBundle package.
  * For the full copyright and license information, please view the LICENSE
@@ -11,37 +10,51 @@
 namespace Propel\PropelBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
-use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 /**
  * Constraint for the Unique Object validator
  *
  * @author Maxime AILLOUD <maxime.ailloud@gmail.com>
+ * @author Marek Kalnik <marekk@theodo.fr>
  */
 class UniqueObject extends Constraint
 {
+    /**
+     * @var string
+     */
+    public $message = 'A {{ object_class }} object already exists with {{ fields }}';
+
+    /**
+     * @var string Used to merge multiple fields in the message
+     */
+    public $messageFieldSeparator = ' and ';
+
     /**
      * @var array
      */
     public $fields = array();
 
+    public function __construct($options = null)
+    {
+        parent::__construct($options);
+
+        if (!is_array($this->fields) && !is_string($this->fields)) {
+            throw new UnexpectedTypeException($this->fields, 'array');
+        }
+
+        if (0 === count($this->fields)) {
+            throw new ConstraintDefinitionException("At least one field must be specified.");
+        }
+    }
+
     /**
-     * @return array
+     * {@inheritDoc}
      */
     public function getRequiredOptions()
     {
         return array('fields');
-    }
-
-    /**
-     * The validator must be defined as a service with this name.
-     *
-     * @return string
-     */
-    public function validatedBy()
-    {
-        return get_class($this).'Validator';
     }
 
     /**
@@ -50,21 +63,5 @@ class UniqueObject extends Constraint
     public function getTargets()
     {
         return self::CLASS_CONSTRAINT;
-    }
-
-    /**
-     * @return string
-     */
-    public function getDefaultOption()
-    {
-        return 'fields';
-    }
-
-    /**
-     * @return string
-     */
-    public function getMessage()
-    {
-        return 'A ' . $this->groups[1] . ' object already exists';
     }
 }

--- a/Validator/Constraints/UniqueObjectValidator.php
+++ b/Validator/Constraints/UniqueObjectValidator.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * This file is part of the PropelBundle package.
  * For the full copyright and license information, please view the LICENSE
@@ -13,31 +12,21 @@ namespace Propel\PropelBundle\Validator\Constraints;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
-use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 /**
  * Unique Object Validator checks if one or a set of fields contain unique values.
  *
  * @author Maxime AILLOUD <maxime.ailloud@gmail.com>
+ * @author Marek Kalnik <marekk@theodo.fr>
  */
 class UniqueObjectValidator extends ConstraintValidator
 {
     /**
-     * @param object $object
-     * @param \Symfony\Component\Validator\Constraint $constraint
-     * @return Boolean
+     * {@inheritdoc}
      */
-    public function isValid($object, Constraint $constraint)
+    public function validate($object, Constraint $constraint)
     {
-        if (!is_array($constraint->fields) && !is_string($constraint->fields)) {
-            throw new UnexpectedTypeException($constraint->fields, 'array');
-        }
-
-        $fields = (array)$constraint->fields;
-
-        if (0 === count($fields)) {
-            throw new ConstraintDefinitionException("At least one field must be specified.");
-        }
+        $fields = (array) $constraint->fields;
 
         $class = get_class($object);
         $peerClass = $class . 'Peer';
@@ -52,26 +41,33 @@ class UniqueObjectValidator extends ConstraintValidator
 
         $bddUsersQuery = $queryClass::create();
         foreach ($fields as $fieldName) {
-            $bddUsersQuery->filterBy($peerClass::translateFieldName($fieldName, \BasePeer::TYPE_FIELDNAME, \BasePeer::TYPE_PHPNAME), $object->getByName($fieldName, \BasePeer::TYPE_FIELDNAME));
+            $bddUsersQuery->filterBy(
+                $peerClass::translateFieldName($fieldName, \BasePeer::TYPE_FIELDNAME, \BasePeer::TYPE_PHPNAME),
+                $object->getByName($fieldName, \BasePeer::TYPE_FIELDNAME)
+            );
         }
         $bddUsers = $bddUsersQuery->find();
 
         $countUser = count($bddUsers);
 
         if ($countUser > 1 || ($countUser === 1 && $object !== $bddUsers[0])) {
-            $constraintMessage = $constraint->getMessage();
-            $constraintMessage .= ' with';
+            $fieldParts = array();
 
             foreach ($fields as $fieldName) {
-              $constraintMessage .= sprintf(' %s "%s" and', $peerClass::translateFieldName($fieldName, \BasePeer::TYPE_FIELDNAME, \BasePeer::TYPE_PHPNAME), $object->getByName($fieldName, \BasePeer::TYPE_FIELDNAME));
+                $fieldParts[] = sprintf(
+                    '%s "%s"',
+                    $peerClass::translateFieldName($fieldName, \BasePeer::TYPE_FIELDNAME, \BasePeer::TYPE_PHPNAME),
+                    $object->getByName($fieldName, \BasePeer::TYPE_FIELDNAME)
+                );
             }
 
-            $constraintMessage = substr($constraintMessage, 0, -4) . '.';
-            $this->setMessage($constraintMessage);
-
-            return false;
+            $this->context->addViolation(
+                $constraint->message,
+                array(
+                    '{{ object_class }}' => $class,
+                    '{{ fields }}' => implode($constraint->messageFieldSeparator, $fieldParts)
+                )
+            );
         }
-
-        return true;
     }
 }


### PR DESCRIPTION
This PR allows setting the message by using 'message' option.

It contains also a refactoring to adapt the code to recent Symfony forms API changes (removes dependency on deprecated functions).

It fixes #160.

The PR should be safe to merge into 1.1 and 2.0 (do you want me to make a separate PR?).
Also note that the namespace is not conform with Symfony2 namespaces (should be Constraint rather than Constraints) but I didn't touch it to avoid BC breaks.
