### PR TITLE
If pk not in request then use ParamConverter name

### DIFF
--- a/Resources/skeleton/FormType.php
+++ b/Resources/skeleton/FormType.php
@@ -8,20 +8,6 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class ##CLASS## extends AbstractType
 {
-    private $options = array(
-        'data_class' => '##FQCN##',
-    );
-
-    public function set($name, $value)
-    {
-        $this->options[$name] = $value;
-    }
-
-    public function get($name)
-    {
-        return $this->options[$name];
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -34,7 +20,9 @@ class ##CLASS## extends AbstractType
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
-        $resolver->setDefaults($this->options);
+        $resolver->setDefaults(array(
+            'data_class' => '##FQCN##',
+        ));
     }
 
     /**


### PR DESCRIPTION
It's useful when using FOSRestBundle with automatic routing loader and ParamConverter.

``` php
    /**
     * @View()
     * @ParamConverter("user", options={"mapping": {"user": "id"}})
     */
    public function getUserAction(Model\User $user)
    {
        return $user;
    }
```

you know FOSRestBundle will generate for this method route like

```
/users/{user}
```

Without that ParamConverter propel can't figure out which parameter is pk
With my changes you don't need to map "user" parameter to "id"
