### PR TITLE
Fix: logic exception thrown instead of a NotFoundHttpException

### DIFF
--- a/Request/ParamConverter/PropelParamConverter.php
+++ b/Request/ParamConverter/PropelParamConverter.php
@@ -190,9 +190,7 @@ class PropelParamConverter implements ParamConverterInterface
         if (!$this->hasWith) {
             return $query->findOne();
         } else {
-            $results = $query->find();
-
-            return reset($results);
+            return $query->find()->first();
         }
     }
 


### PR DESCRIPTION
In some specific cases (filter on a non-PK field, "with" option defined and non optionnal value), if the object to convert is not found a LogicException is raised instead a NotFoundHttpException one.
