### PR TITLE
added generation of Base*Type class

### DIFF
--- a/Form/BaseAbstractType.php
+++ b/Form/BaseAbstractType.php
@@ -3,6 +3,7 @@
 namespace Propel\PropelBundle\Form;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 abstract class BaseAbstractType extends AbstractType
@@ -11,6 +12,9 @@ abstract class BaseAbstractType extends AbstractType
         'name' => '',
     );
 
+    /** @var Field[] */
+    protected $fields = array();
+
     function __construct($mergeOptions = null)
     {
         if ($mergeOptions) {
@@ -18,9 +22,20 @@ abstract class BaseAbstractType extends AbstractType
         }
     }
 
+    protected function setup()
+    {
+
+    }
+
+    protected function configure()
+    {
+
+    }
+
     public function setOption($name, $value)
     {
         $this->options[$name] = $value;
+        return $this;
     }
 
     public function getOption($name)
@@ -31,6 +46,7 @@ abstract class BaseAbstractType extends AbstractType
     public function setOptions($options)
     {
         $this->options = $options;
+        return $this;
     }
 
     public function getOptions()
@@ -41,6 +57,37 @@ abstract class BaseAbstractType extends AbstractType
     public function mergeOptions($options)
     {
         $this->options = array_merge($this->options, $options);
+        return $this;
+    }
+
+    public function setField($name, Field $field)
+    {
+        $this->fields[$name] = $field;
+        return $this;
+    }
+
+    public function setFields($fields)
+    {
+        foreach($fields as $name => $field) {
+            $this->setField($name, $field);
+        }
+        return $this;
+    }
+
+    public function getFields()
+    {
+        return $this->fields;
+    }
+
+    public function getField($name)
+    {
+        return $this->fields[$name];
+    }
+
+    public function removeField($name)
+    {
+        unset($this->fields[$name]);
+        return $this;
     }
 
     /**
@@ -58,4 +105,17 @@ abstract class BaseAbstractType extends AbstractType
     {
         return $this->getOption('name');
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $this->setup();
+        $this->configure();
+        foreach($this->getFields() as $name => $field) {
+            $builder->add($name, $field->getType(), $field->getOptions());
+        }
+    }
+
 }

--- a/Form/Field.php
+++ b/Form/Field.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Propel\PropelBundle\Form;
+ 
+class Field
+{
+    private $type, $options;
+
+    function __construct($type = null, $options = array())
+    {
+        $this->setType($type);
+        $this->setOptions($options);
+    }
+
+
+    public function setOptions($options)
+    {
+        $this->options = $options;
+        return $this;
+    }
+
+    public function getOptions()
+    {
+        return $this->options;
+    }
+
+    public function setType($type)
+    {
+        $this->type = $type;
+        return $this;
+    }
+
+    public function getType()
+    {
+        return $this->type;
+    }
+
+}

--- a/Resources/skeleton/BaseFormType.php
+++ b/Resources/skeleton/BaseFormType.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace /*#NAMESPACE#*/;
+
+use Propel\PropelBundle\Form\BaseAbstractType;
+use Propel\PropelBundle\Form\Field;
+
+class /*#CLASS#*/ extends BaseAbstractType
+{
+    protected function setup()
+    {
+        $this->setOptions(array(
+            'data_class' => '/*#FQCN#*/',
+            'name'       => '/*#TYPE_NAME#*/',
+        ));
+
+        $this->setFields(array(/*#FIELDS#*/
+        ));
+    }
+}

--- a/Resources/skeleton/FormType.php
+++ b/Resources/skeleton/FormType.php
@@ -1,21 +1,12 @@
 <?php
 
-namespace ##NAMESPACE##;
+namespace /*#NAMESPACE#*/;
 
-use Propel\PropelBundle\Form\BaseAbstractType;
-use Symfony\Component\Form\FormBuilderInterface;
 
-class ##CLASS## extends BaseAbstractType
+class /*#CLASS#*/ extends /*#EXTENDS#*/
 {
-    protected $options = array(
-        'data_class' => '##FQCN##',
-        'name'       => '##TYPE_NAME##',
-    );
-
-    /**
-     * {@inheritdoc}
-     */
-    public function buildForm(FormBuilderInterface $builder, array $options)
-    {##BUILD_CODE##
+    protected function configure()
+    {
+        /* your code here */
     }
 }


### PR DESCRIPTION
In Propel for symfony 1.4 forms have base class (which rewrites every time when schema was changed) and main class (which never rewrites). I'd like to have same thing in symfony 2.

Example

Foo\BarBundle\Form\Base\BaseUserType.php

``` php
namespace Foo\BarBundle\Form\Type\Base;

use Propel\PropelBundle\Form\BaseAbstractType;
use Propel\PropelBundle\Form\Field;

class BaseUserType extends BaseAbstractType
{
    protected function setup()
    {
        $this->setOptions(array(
            'data_class' => 'Foo\BarBundle\Model\User',
            'name'       => 'user',
        ));

        $this->setFields(array(
            'name' => new Field(),
            'password' => new Field(),
            'created_at' => new Field(),
        ));
    }
}
```

Foo\BarBundle\Form\UserType.php

``` php
namespace Foo\BarBundle\Form\Type;

class UserType extends Base\BaseUserType
{
    protected function configure()
    {
        $this->getField('created_at')
            ->setType('date')
            ->setOptions(array('widget'=>'single_text'))
        ;
    }
}

```

and in BaseAbstractType we have implementation of buildForm()

``` php
    public function buildForm(FormBuilderInterface $builder, array $options)
    {
        $this->setup();
        $this->configure();
        foreach($this->getFields() as $name => $field) {
            $builder->add($name, $field->getType(), $field->getOptions());
        }
    }
```
