### PR TITLE
[UniqueObjectValidator] add a new errorPath parameter

### DIFF
--- a/Resources/doc/unique_object_validator.markdown
+++ b/Resources/doc/unique_object_validator.markdown
@@ -5,6 +5,17 @@ In a form, if you want to validate the uniqueness of a field in a table you have
 
 You may use as many validators of this type as you want.
 
+The validator has 1 required parameter:
+
+* `fields` : a field or an array of fields to test for uniqueness
+
+and 3 optionals parameters:
+
+* `message` : the error message with two variable `{{ object_class }}` and `{{ fields }}`
+* `messageFieldSeparator` : the field separator ` and `
+* `errorPath` : the relative path where the error will be attached, if none is set the error is global.
+
+
 YAML
 ----
 
@@ -13,7 +24,8 @@ You can specify this using the `validation.yml` file, like this:
 ``` yaml
 Acme\DemoBundle\Model\User:
     constraints:
-        - Propel\PropelBundle\Validator\Constraints\UniqueObject: username
+        - Propel\PropelBundle\Validator\Constraints\UniqueObject: 
+            fields:  username
 ```
 
 If you want to validate the uniqueness of more than just one field:
@@ -21,7 +33,20 @@ If you want to validate the uniqueness of more than just one field:
 ``` yaml
 Acme\DemoBundle\Model\User:
     constraints:
-        - Propel\PropelBundle\Validator\Constraints\UniqueObject: [username, login]
+        - Propel\PropelBundle\Validator\Constraints\UniqueObject: 
+            fields: [username, login]
+```
+
+Full configuration :
+
+``` yaml
+Acme\DemoBundle\Model\User:
+    constraints:
+        - Propel\PropelBundle\Validator\Constraints\UniqueObject: 
+            fields: [username, login]
+            message: We already have a user with {{ fields }}
+            messageFieldSeparator: " and "
+            errorPath: username
 ```
 
 PHP
@@ -45,7 +70,9 @@ use Propel\PropelBundle\Validator\Constraint\UniqueObject;
             new UniqueObject(
                 array(
                     'fields' => 'username',
-                    'message' => 'We already have a user with {{ fields }}'
+                    'message' => 'We already have a user with {{ fields }}',
+                    'messageFieldSeparator' => ' and '
+                    'errorPath' => 'username',
                 )
             )
         );
@@ -61,8 +88,10 @@ If there is more than one field you must use an array
         $metadata->addConstraint(
             new UniqueObject(
                 array(
-                    'fields' => array('username', 'login')
-                    'message' => 'We already have a user with {{ fields }}'
+                    'fields' => array('username', 'login'),
+                    'message' => 'We already have a user with {{ fields }}',
+                    'messageFieldSeparator' => ' and ',
+                    'errorPath' => 'username'
                 )
             )
         );
@@ -72,8 +101,24 @@ If there is more than one field you must use an array
 ```
 
 
+XML
+---
 
+You can also specify this using xml
 
+```xml
+
+    <class name="Acme\DemoBundle\Model\User">
+        
+        <constraint name="Propel\PropelBundle\Validator\Constraints\UniqueObject">
+            <option name="fields">username</option>
+            <option name="message">We already have a user with {{ fields }}</option>
+            <option name="messageFieldSeparator"> and </option>
+            <option name="errorPath">username</option>
+        </constraint>
+        
+    </class>
+```
 
 
 [Back to index](index.markdown)

--- a/Validator/Constraints/UniqueObject.php
+++ b/Validator/Constraints/UniqueObject.php
@@ -37,6 +37,11 @@ class UniqueObject extends Constraint
      */
     public $fields = array();
 
+    /**
+     * @var string Used to set the path where the error will be attached, default is global.
+     */
+    public $errorPath;
+
     public function __construct($options = null)
     {
         parent::__construct($options);
@@ -47,6 +52,10 @@ class UniqueObject extends Constraint
 
         if (0 === count($this->fields)) {
             throw new ConstraintDefinitionException("At least one field must be specified.");
+        }
+
+        if (null !== $this->errorPath && !is_string($this->errorPath)) {
+            throw new UnexpectedTypeException($this->errorPath, 'string or null');
         }
     }
 

--- a/Validator/Constraints/UniqueObjectValidator.php
+++ b/Validator/Constraints/UniqueObjectValidator.php
@@ -61,13 +61,15 @@ class UniqueObjectValidator extends ConstraintValidator
                 );
             }
 
-            $this->context->addViolation(
+            $this->context->addViolationAtSubPath(
+                $constraint->errorPath,
                 $constraint->message,
                 array(
                     '{{ object_class }}' => $class,
                     '{{ fields }}' => implode($constraint->messageFieldSeparator, $fieldParts)
                 )
             );
+
         }
     }
 }


### PR DESCRIPTION
Hi,

This add an optional parameter : `errorPath` to the `UniqueObjectValidator`

it allow to set the path of a relative field the attach the error to the field.

By default (empty) the error is global so this change is BC.

I update the doc that was outdated and add XML configuration format
