### PR TITLE
allow backwards compatible versions of Symfony

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,11 @@
     "email": "william.durand1@gmail.com"
   }],
   "require": {
-    "symfony/symfony": "~2.2.0",
+    "symfony/symfony": "~2.2",
     "propel/propel1": "~1.6"
   },
   "require-dev": {
-    "sensio/framework-extra-bundle": "~2.2.0",
+    "sensio/framework-extra-bundle": "~2.2",
     "fzaninotto/faker": "dev-master"
   },
   "autoload": {


### PR DESCRIPTION
Tests do not pass on PHP 5.4, but Symfony 2.3 seems working.

Let's see, what Travis says.

fixes #227
