### PR TITLE
Data dumper - Escape column and table names with `

### DIFF
--- a/DataFixtures/Dumper/AbstractDataDumper.php
+++ b/DataFixtures/Dumper/AbstractDataDumper.php
@@ -107,7 +107,7 @@ abstract class AbstractDataDumper extends AbstractDataHandler implements DataDum
                 }
                 $stmt = $this
                     ->con
-                    ->query(sprintf('SELECT %s FROM %s', implode(',', $in), constant(constant($tableName.'::PEER').'::TABLE_NAME')));
+                    ->query(sprintf('SELECT %s FROM %s', '`'.implode('`,`', $in).'`', '`'.constant(constant($tableName.'::PEER').'::TABLE_NAME').'`'));
 
                 $resultsSets[] = $stmt->fetchAll(PDO::FETCH_ASSOC);
                 $stmt->closeCursor();


### PR DESCRIPTION
If you have a column named `key` (which is valid) a DB error is thrown because the field names aren't escaped.
