### PR TITLE
Escape columns name in DataDumper

### DIFF
--- a/DataFixtures/Dumper/AbstractDataDumper.php
+++ b/DataFixtures/Dumper/AbstractDataDumper.php
@@ -103,7 +103,7 @@ abstract class AbstractDataDumper extends AbstractDataHandler implements DataDum
             } else {
                 $in = array();
                 foreach ($tableMap->getColumns() as $column) {
-                    $in[] = strtolower($column->getName());
+                    $in[] = '`'.strtolower($column->getName()).'`';
                 }
                 $stmt = $this
                     ->con


### PR DESCRIPTION
Escape columns name in DataDumper to prevent SQL syntax error when the column name is a reserved word (like order, key, date etc).

This error appears when app/console propel:fixtures:dump command is run.
