### PR TITLE
read route options in PropelParamConverter

### DIFF
--- a/Request/ParamConverter/PropelParamConverter.php
+++ b/Request/ParamConverter/PropelParamConverter.php
@@ -4,9 +4,11 @@ namespace Propel\PropelBundle\Request\ParamConverter;
 
 use Propel\PropelBundle\Util\PropelInflector;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationInterface;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\RouterInterface;
 
 /**
  * PropelParamConverter
@@ -52,6 +54,16 @@ class PropelParamConverter implements ParamConverterInterface
     protected $hasWith = false;
 
     /**
+     * @var RouterInterface
+     */
+    protected $router;
+
+    public function setRouter(RouterInterface $router = null)
+    {
+        $this->router = $router;
+    }
+
+    /**
      * @param Request                $request
      * @param ConfigurationInterface $configuration
      *
@@ -80,6 +92,14 @@ class PropelParamConverter implements ParamConverterInterface
         }
 
         $options = $configuration->getOptions();
+
+        // Check route options for converter options, if there are non provided.
+        if (empty($options) && $this->router && $configuration instanceof ParamConverter) {
+            $converterOption = $this->router->getRouteCollection()->get($request->attributes->get('_route'))->getOption('propel_converter');
+            if (!empty($converterOption[$configuration->getName()])) {
+                $options = $converterOption[$configuration->getName()];
+            }
+        }
 
         if (isset($options['mapping'])) {
             // We use the mapping for calling findPk or filterBy

--- a/Resources/config/converters.xml
+++ b/Resources/config/converters.xml
@@ -11,6 +11,10 @@
     <services>
         <service id="propel.converter.propel.orm" class="%propel.converter.propel.class%">
             <tag name="request.param_converter" priority="10" />
+
+            <call method="setRouter">
+                <argument type="service" id="router" on-invalid="null" />
+            </call>
         </service>
     </services>
 </container>


### PR DESCRIPTION
Enables a new route option to configure the param converter, if you are not using annotations.
