### PR TITLE
Update PropelParamConverter.php

### DIFF
--- a/Request/ParamConverter/PropelParamConverter.php
+++ b/Request/ParamConverter/PropelParamConverter.php
@@ -95,7 +95,7 @@ class PropelParamConverter implements ParamConverterInterface
 
         // Check route options for converter options, if there are non provided.
         if (empty($options) && $request->attributes->has('_route') && $this->router && $configuration instanceof ParamConverter) {
-            $converterOption = $this->router->getRouteCollection()->get($request->attributes->get('_route'))->getOption('propel_converter');
+            $converterOption = $this->router->getOriginalRouteCollection()->get($request->attributes->get('_route'))->getOption('propel_converter');
             if (!empty($converterOption[$configuration->getName()])) {
                 $options = $converterOption[$configuration->getName()];
             }


### PR DESCRIPTION
Some Bundle can change the original route name in collection. This happen after I use jms/i18n-routing-bundle. This bundle change original route collection name with locale. Example: en__US__route_name.

FatalErrorException: Error: Call to a member function getOption() on a non-object in /var/www/symfony2/project/vendor/propel/propel-bundle/Propel/PropelBundle/Request/ParamConverter/PropelParamConverter.php line 99
