### PR TITLE
fix Sensio FrameworkExtraBundle v3.0 ParamConverterInterface compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ php:
   - 5.5
 
 env:
-  - SYMFONY_VERSION=2.2.*
-  - SYMFONY_VERSION=2.3.*
+  - SYMFONY_VERSION=2.4.*
   - SYMFONY_VERSION=dev-master
 
 matrix:

--- a/README.markdown
+++ b/README.markdown
@@ -11,14 +11,16 @@ As `Propel2` will be released in the near future, we are migrating the branching
 
 * The `1.0` branch contains Propel *1.6* integration for Symfony *2.0* (*currently 2.0 branch*).
 * The `1.1` branch contains Propel *1.6* integration for Symfony *2.1* (*currently 2.1 branch*).
-* The `1.2` branch contains Propel *1.6* integration for Symfony *>2.1* (*currently 2.2, 2.3 and 2.4 branch*).
+* The `1.2` branch contains Propel *1.6* integration for Symfony *>2.1* (*currently 2.2 and 2.3 *).
+* The `1.3` branch contains Propel *1.6* integration for Symfony *>2.3* (*currently 2.4 and master branch*).
 * The `2.0` branch will contain `Propel2` integration for Symfony *2.1*.
   We are still considering to integrate `Propel2` with Symfony *2.0*.
   In case, we will do so, there will be a `2.1` and `2.0` branch integrating the respective Symfony version!
 
 **The 1.x branches are already available and you are encouraged to migrate your dependencies according to the listings!**
 
-* If you depend on Symfony `2.2`, `2.3` or `master` branch, switch to the `1.2` branch.
+* If you depend on Symfony `2.4` or `master` branch, switch to the `1.3` branch.
+* If you depend on Symfony `2.2` or `2.3`  branch, switch to the `1.2` branch.
 * If you depend on Symfony `2.1` branch, switch to the `1.1` branch.
 * If you depend on Symfony `2.0` branch, switch to the `1.0` branch.
 

--- a/Request/ParamConverter/PropelParamConverter.php
+++ b/Request/ParamConverter/PropelParamConverter.php
@@ -3,7 +3,6 @@
 namespace Propel\PropelBundle\Request\ParamConverter;
 
 use Propel\PropelBundle\Util\PropelInflector;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -65,7 +64,7 @@ class PropelParamConverter implements ParamConverterInterface
 
     /**
      * @param Request                $request
-     * @param ConfigurationInterface $configuration
+     * @param ParamConverter $configuration
      *
      * @return bool
      *
@@ -73,7 +72,7 @@ class PropelParamConverter implements ParamConverterInterface
      * @throws NotFoundHttpException
      * @throws \Exception
      */
-    public function apply(Request $request, ConfigurationInterface $configuration)
+    public function apply(Request $request, ParamConverter $configuration)
     {
         $classQuery = $configuration->getClass() . 'Query';
         $classPeer = $configuration->getClass() . 'Peer';
@@ -142,11 +141,11 @@ class PropelParamConverter implements ParamConverterInterface
     }
 
     /**
-     * @param ConfigurationInterface $configuration
+     * @param ParamConverter $configuration
      *
      * @return bool
      */
-    public function supports(ConfigurationInterface $configuration)
+    public function supports(ParamConverter $configuration)
     {
         if (null === ($classname = $configuration->getClass())) {
             return false;

--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,11 @@
     "email": "william.durand1@gmail.com"
   }],
   "require": {
-    "symfony/symfony": "~2.2",
+    "symfony/symfony": "~2.4",
     "propel/propel1": "~1.6"
   },
   "require-dev": {
-    "sensio/framework-extra-bundle": "~2.2",
+    "sensio/framework-extra-bundle": "~3.0",
     "fzaninotto/faker": "dev-master"
   },
   "autoload": {


### PR DESCRIPTION
Since Symfony 2.4 , required `sensio/framework-extra-bundle` version is >= 3.0.

But the `Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface` signature has changed (See `Request/ParamConverter/PropelParamConverter.php`).

Maybe we should create a 1.3 branch which require `symfony/symfony` >= 2.4  and `sensio/framework-extra-bundle version >= 3.0.
