### PR TITLE
Added quoting for column names in fixtures dumper

### DIFF
--- a/DataFixtures/Dumper/AbstractDataDumper.php
+++ b/DataFixtures/Dumper/AbstractDataDumper.php
@@ -103,7 +103,7 @@ abstract class AbstractDataDumper extends AbstractDataHandler implements DataDum
             } else {
                 $in = array();
                 foreach ($tableMap->getColumns() as $column) {
-                    $in[] = strtolower($column->getName());
+                    $in[] = '`' . strtolower($column->getName()) . '`';
                 }
                 $stmt = $this
                     ->con


### PR DESCRIPTION
Fix problems, if column was named like SQL-commands, operators, etc
