### PR TITLE
Correct prefix when PSR-4 bundle

### DIFF
--- a/Command/AbstractCommand.php
+++ b/Command/AbstractCommand.php
@@ -77,7 +77,13 @@ abstract class AbstractCommand extends ContainerAwareCommand
     protected function getPackagePrefix(Bundle $bundle, $baseDirectory = '')
     {
         $parts  = explode(DIRECTORY_SEPARATOR, realpath($bundle->getPath()));
-        $length = count(explode('\\', $bundle->getNamespace())) * (-1);
+        $segments = explode('\\', $bundle->getNamespace());
+        $length = count($parts);
+
+        $partsDiff = array_diff($segments, $parts);
+        if (empty($partsDiff)) {
+            $length = count(explode('\\', $bundle->getNamespace())) * (-1);
+        }
 
         $prefix = implode(DIRECTORY_SEPARATOR, array_slice($parts, 0, $length));
         $prefix = ltrim(str_replace($baseDirectory, '', $prefix), DIRECTORY_SEPARATOR);
@@ -95,7 +101,7 @@ abstract class AbstractCommand extends ContainerAwareCommand
     protected function initialize(InputInterface $input, OutputInterface $output)
     {
         parent::initialize($input, $output);
-        
+
         if ($input->getOption('verbose')) {
             $this->additionalPhingArgs[] = 'verbose';
         }


### PR DESCRIPTION
Recently the BazingaOAuthBundle moved to a PSR-4 folder structure and it seems that the PropelBundle doesn't handle this structure correctly. Assuming I have a project with both the BazingaOAuthBundle and the FOSUserBundle and I am trying to generate the correct model classes;

**FOSUserBundle**
_$bundle->getPath()_ => /vendor/friendsofsymfony/user-bundle/FOS/UserBundle
_$bundle->getNamespace()_ => FOS\UserBundle
_$prefix_ => vendor.friendsofsymfony.user-bundle.

**BazingaOAuthBundle**
_$bundle->getPath()_ => /vendor/willdurand/oauth-server-bundle
_$bundle->getNamespace()_ => Bazinga\OAuthServerBundle
_$prefix_ => vendor.

This pull request fixes the generation of the prefix. I am still looking at the class generation of Propel itself. This should be `/vendor/willdurand/oauth-server-bundle/Propel` but is `/vendor/willdurand/oauth-server-bundle/Bazinga/OAuthServerBundle/Propel`.
