### PR TITLE
Use the configured paths for Porpel and Phing

### DIFF
--- a/DependencyInjection/PropelExtension.php
+++ b/DependencyInjection/PropelExtension.php
@@ -44,20 +44,16 @@ class PropelExtension extends Extension
             $container->setParameter('propel.phing_path', $phingPath);
         }
 
-        if (!$container->hasParameter('propel.path')) {
-            if (!isset($config['path'])) {
-                throw new \InvalidArgumentException('PropelBundle expects a "path" parameter that must contain the absolute path to the Propel ORM vendor library. The "path" parameter must be defined under the "propel" root node in your configuration.');
-            } else {
-                $container->setParameter('propel.path', $config['path']);
-            }
+        if (isset($config['path'])) {
+            $container->setParameter('propel.path', $config['path']);
+        } elseif (!$container->hasParameter('propel.path')) {
+            throw new \InvalidArgumentException('PropelBundle expects a "path" parameter that must contain the absolute path to the Propel ORM vendor library. The "path" parameter must be defined under the "propel" root node in your configuration.');
         }
 
-        if (!$container->hasParameter('propel.phing_path')) {
-            if (!isset($config['phing_path'])) {
+        if (isset($config['phing_path'])) {
+            $container->setParameter('propel.phing_path', $config['phing_path']);
+        } elseif (!$container->hasParameter('propel.phing_path')) {
                 throw new \InvalidArgumentException('PropelBundle expects a "phing_path" parameter that must contain the absolute path to the Phing vendor library. The "phing_path" parameter must be defined under the "propel" root node in your configuration.');
-            } else {
-                $container->setParameter('propel.phing_path', $config['phing_path']);
-            }
         }
 
         if (isset($config['logging']) && $config['logging']) {


### PR DESCRIPTION
This PR let the end user to configure the paths to Propel and Phing in the configuration file. 

I have a symfony 1.4 project wich uses Propel and a Symfony 2 one that will use the same model. I wanted to tell Syfmony 2 to use the version of Propel installed in the symfony 1.4 to avoid autoloading issues. 
