### PR TITLE
Propel default db should be a connection name, not an array of configuration

### DIFF
--- a/DependencyInjection/PropelExtension.php
+++ b/DependencyInjection/PropelExtension.php
@@ -132,7 +132,7 @@ class PropelExtension extends Extension
 
         // Alias the default connection if not defined
         if (!isset($c['datasources']['default'])) {
-            $c['datasources']['default'] = $c['datasources'][$connectionName];
+            $c['datasources']['default'] = $connectionName;
         }
 
         $container->getDefinition('propel.configuration')->setArguments(array($c));


### PR DESCRIPTION
If you don't have a connection named `default` the bundle tries to set a default connection name. Instead of setting the connection name to a string it's setting it to an array of configuration details.

More details in [ticket 295](https://github.com/propelorm/PropelBundle/issues/295)
