### PR TITLE
Update index.markdown

### DIFF
--- a/Resources/doc/index.markdown
+++ b/Resources/doc/index.markdown
@@ -8,13 +8,8 @@ This is the official implementation of [Propel](http://www.propelorm.org/) in Sy
 
 The recommended way to install this bundle is to rely on [Composer](http://getcomposer.org):
 
-``` javascript
-{
-    "require": {
-        // ...
-        "propel/propel-bundle": "1.1.*"
-    }
-}
+```sh
+composer require propel/propel-bundle
 ```
 
 Otherwise you can use Git, SVN, Git submodules, or the Symfony vendor management (deps file):


### PR DESCRIPTION
Updated installation instructions via composer to use the `composer require` command without specifying a version.
This is the new recommended way of providing this information and it leads to composer picking the proper version constraint (i.e ~1.2), updating the `composer.json` and running install, all in one command.
