### PR TITLE
Forbid dots in connection names

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -35,6 +35,18 @@ class Configuration extends PropelConfiguration
                     ->children()
                         ->arrayNode('connections')
                             ->isRequired()
+                            ->validate()
+                            ->always()
+                                ->then(function($connections) {
+                                    foreach ($connections as $name => $connection) {
+                                        if (strpos($name, '.') !== false) {
+                                            throw new \InvalidArgumentException('Dots are not allowed in connection names');
+                                        }
+                                    }
+
+                                    return $connections;
+                                })
+                            ->end()
                             ->requiresAtLeastOneElement()
                             ->normalizeKeys(false)
                             ->prototype('array')


### PR DESCRIPTION
Just a port of [this commit](https://github.com/propelorm/Propel2/commit/9c0a280bdaf0808098c3560b40dd2590c3297946)
