### PR TITLE
[v2] Correctly merge connection settings from multiple config files

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -37,6 +37,7 @@ class Configuration extends PropelConfiguration
                             ->isRequired()
                             ->requiresAtLeastOneElement()
                             ->normalizeKeys(false)
+                            ->useAttributeAsKey('id')
                             ->prototype('array')
                             ->fixXmlConfig('slave')
                                 ->children()


### PR DESCRIPTION
This PR allows to correctly merge connection settings defined in multiple config files - i.e. overriding database connection settings for development environment.

Example:

``` yaml
config.yml
...
propel:
    database:
        connections:
            default:
                adapter:    "%database_driver%"
                dsn:        "%database_driver%:host=%database_host%;dbname=%database_name%;charset=UTF8"
                user:       "%database_user%"
                password:   "%database_password%"
...

config_dev.yml
...
propel:
    database:
        connections:
            default:
                classname: Propel\Runtime\Connection\ProfilerConnectionWrapper

...
```

Without this fix, the definition from `config_dev.yml` is considered as a completely new connection and the validation fails.

Another question is, wouldn't be better for this to go upstream in `PropelConfiguration`? 
