### PR TITLE
Do not pass --platform option to subcommands if NULL

### DIFF
--- a/Command/AbstractCommand.php
+++ b/Command/AbstractCommand.php
@@ -194,8 +194,8 @@ abstract class AbstractCommand extends ContainerAwareCommand
 
         $parameters = array_merge($extraParameters, $parameters);
 
-        if ($input->hasOption('platform')) {
-            $parameters['--platform'] = $input->getOption('platform') ?: $this->getPlatform();
+        if ($input->hasOption('platform') && ($platform = $input->getOption('platform') ?: $this->getPlatform()) !== null) {
+            $parameters['--platform'] = $platform;
         }
 
         $command->setApplication($this->getApplication());


### PR DESCRIPTION
As it would result in an InvalidArgumentException: The "--platform" option
requires a value.
