### PR TITLE
Do not translate choices of model type

### DIFF
--- a/Form/Type/ModelType.php
+++ b/Form/Type/ModelType.php
@@ -96,6 +96,7 @@ class ModelType extends AbstractType
             'group_by'          => null,
             'by_reference'      => false,
             'index_property'    => null,
+            'choice_translation_domain' => false,
         ));
     }
 


### PR DESCRIPTION
This avoids "missing translation" errors:

![screenshot 2015-08-10 14 54 51](https://cloud.githubusercontent.com/assets/330436/9172070/e598c624-3f70-11e5-9eb3-a925b12ccb7e.png)

In doctrine's form types it is set to false, too: https://github.com/symfony/symfony/blob/2.8/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php#L310