### PR TITLE
Fix #257 - Prevent symlink paths resolving in fixtures loading

### DIFF
--- a/Command/FixturesLoadCommand.php
+++ b/Command/FixturesLoadCommand.php
@@ -277,7 +277,9 @@ EOT
     protected function getFixtureFiles($type = 'sql', $in = null)
     {
         $finder = new Finder();
-        $finder->sortByName()->name('*.' . $type);
+        $finder->sort(function ($a, $b) {
+            return strcmp($a->getPathname(), $b->getPathname());
+        })->name('*.' . $type);
 
         $files = $finder->in(null !== $in ? $in : $this->absoluteFixturesPath);
 


### PR DESCRIPTION
I didn't add any tests because I did not find any tests for the fixtures command. But if you need it, I can try to add some...

The aim of this PR is to fix the bugs linked to the use of symlinks in fixtures: the sortByName function compares using the getRealPath method of SplFileInfo that resolves the symlinks.
This has for effect not to load the symlinked fixtures from their path but from their target file location. This behavior can sometime be very confusing:

Example:

    app/propel/fixtures/common/00-company.yml
    app/propel/fixtures/basedata/00-company.yml  -> app/propel/fixtures/common/00-company.yml
    app/propel/fixtures/basedata/10-user.yml

    php app/console propel:fixtures:load -d app/propel/fixtures/basedata/

Before my fix, the 10-user.yml file would be processed before the 00-company.yml file (because the symlink basedata/00-company.yml will be converted to its target path common/00-company.yml and "b" < "c")

My fix consists in changing the sorting in order not to take the resolved path but taking the original path. This being done only in the sorting, it does not change the fact that the symlinked file is still readable afterwards.