### PR TITLE
Replace deprecated Twig_Filter_Method class

### DIFF
--- a/Twig/Extension/SyntaxExtension.php
+++ b/Twig/Extension/SyntaxExtension.php
@@ -22,7 +22,7 @@ class SyntaxExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            'format_sql'    => new \Twig_Filter_Method($this, 'formatSQL', array('is_safe' => array('html'))),
+            new \Twig_SimpleFilter('format_sql', array($this, 'formatSQL', array('is_safe' => array('html')))),
         );
     }
 


### PR DESCRIPTION
The Twig_Filter_Method class is deprecated since version 1.12 and will be removed in 2.0. Use Twig_SimpleFilter instead.