### PR TITLE
don't enforce semicolon at end of dsn

### DIFF
--- a/Command/DatabaseCreateCommand.php
+++ b/Command/DatabaseCreateCommand.php
@@ -91,7 +91,7 @@ class DatabaseCreateCommand extends AbstractCommand
         $dbName = $this->parseDbName($config['dsn']);
 
         $config['dsn'] = preg_replace(
-            '#dbname='.$dbName.';#',
+            '#dbname='.$dbName.';?#',
             '',
             $config['dsn']
         );


### PR DESCRIPTION
propel:database:create is not working if you have dbname at end of dsn without semicolon