### PR TITLE
Fix SQL formatter to return safe html again

### DIFF
--- a/Twig/Extension/SyntaxExtension.php
+++ b/Twig/Extension/SyntaxExtension.php
@@ -22,7 +22,7 @@ class SyntaxExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            new \Twig_SimpleFilter('format_sql', array($this, 'formatSQL', array('is_safe' => array('html')))),
+            new \Twig_SimpleFilter('format_sql', array($this, 'formatSQL'), array('is_safe' => array('html'))),
             new \Twig_SimpleFilter('format_memory', array($this, 'formatMemory')),
         );
     }


### PR DESCRIPTION
Wrong brackets broke the formatter, returning "unescaped" HTML, so the syntax got escaped again and we ended with visible &lt;span&gt; tags