### PR TITLE
Сhanged Twig filters for 3.0

### DIFF
--- a/Twig/Extension/SyntaxExtension.php
+++ b/Twig/Extension/SyntaxExtension.php
@@ -22,8 +22,8 @@ class SyntaxExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            new \Twig_SimpleFilter('format_sql', array($this, 'formatSQL', array('is_safe' => array('html')))),
-            new \Twig_SimpleFilter('format_memory', array($this, 'formatMemory')),
+            new \Twig_Filter('format_sql', [$this, 'formatSQL'], ['is_safe' => ['html']]),
+            new \Twig_Filter('format_memory', [$this, 'formatMemory']),
         );
     }
 


### PR DESCRIPTION
I got an exception
> Catchable Fatal Error: Argument 2 passed to Twig_Filter::__construct() must be callable, array given, called in vendor/propel/propel-bundle/Twig/Extension/SyntaxExtension.php on line 25 and defined

Now Twig_SimpleFilter is deprecated, and we need use Twig_Filter, but Twig_Filter have second parameter callable, and  third parameter options.
I separated our array for two arrays, and changed function name