### PR TITLE
add raw filter so sql is formatted

### DIFF
--- a/Resources/views/Collector/propel.html.twig
+++ b/Resources/views/Collector/propel.html.twig
@@ -112,7 +112,7 @@
             <tr>
                 <td>
                     <a name="propel-query-{{ i }}" ></a>
-                    <code>{{ query.sql|format_sql }}</code>
+                    <code>{{ query.sql|format_sql|raw }}</code>
                     {% if app.request.query.has('query') and app.request.query.get('query') == i %}
                         <div class="SQLExplain">
                         {% render controller('PropelBundle:Panel:explain', {


### PR DESCRIPTION
If autoescape is on, then the SQL HTML is displayed instead of formatted sql.  This will allow the Symfony debug toolbar to display formatted SQL regardless of the autoescape settings.

https://github.com/propelorm/PropelBundle/issues/380