### PR TITLE
enforce error message if bundle argument is set

### DIFF
--- a/Command/AbstractCommand.php
+++ b/Command/AbstractCommand.php
@@ -128,11 +128,13 @@ abstract class AbstractCommand extends ContainerAwareCommand
 
         $this->checkConfiguration();
 
-        if ($input->hasArgument('bundle') && '@' === substr($input->getArgument('bundle'), 0, 1)) {
-            $this->bundle = $this
-                ->getContainer()
-                ->get('kernel')
-                ->getBundle(substr($input->getArgument('bundle'), 1));
+        if ($input->hasArgument('bundle')) {
+            $bundleName = $input->getArgument('bundle');
+            if (0 === strpos($bundleName, '@')) {
+                $bundleName = substr($bundleName, 1);
+            }
+
+            $this->bundle = $this->getContainer()->get('kernel')->getBundle($bundleName);
         }
     }
 


### PR DESCRIPTION
This fixes #180.

The kernel will throw an exception if the bundle could not be found, which also contains the name of the bundle.
