### PR TITLE
combine schema files into one AppData

### DIFF
--- a/Command/FormGenerateCommand.php
+++ b/Command/FormGenerateCommand.php
@@ -52,8 +52,11 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         if ($schemas = $this->getSchemasFromBundle($this->bundle)) {
+            $schemas = $this->getFinalSchemas($this->getContainer()->get('kernel'));
+
+            $transformer = new \XmlToAppData(null, null, 'UTF-8');
             foreach ($schemas as $fileName => $array) {
-                foreach ($this->getDatabasesFromSchema($array[1]) as $database) {
+                foreach ($this->getDatabasesFromSchema($array[1], $transformer) as $database) {
                     $this->createFormTypeFromDatabase($this->bundle, $database, $input->getArgument('models'), $output, $input->getOption('force'));
                 }
             }

--- a/Command/GeneratorAwareCommand.php
+++ b/Command/GeneratorAwareCommand.php
@@ -38,9 +38,12 @@ abstract class GeneratorAwareCommand extends AbstractCommand
         set_include_path(sprintf('%s/generator/lib', $propelPath) . PATH_SEPARATOR . get_include_path());
     }
 
-    protected function getDatabasesFromSchema(\SplFileInfo $file)
+    protected function getDatabasesFromSchema(\SplFileInfo $file, \XmlToAppData $transformer = null)
     {
-        $transformer = new \XmlToAppData(null, null, 'UTF-8');
+        if (null === $transformer) {
+            $transformer = new \XmlToAppData(null, null, 'UTF-8');
+        }
+
         $config      = new \QuickGeneratorConfig();
 
         if (file_exists($propelIni = $this->getContainer()->getParameter('kernel.root_dir') . '/config/propel.ini')) {


### PR DESCRIPTION
This fixes #173.

In case the schema.xml files are referenced across multiple bundles, the \AppData needs to be extended by each bundle, before reading data from the respective \Database.
