### PR TITLE
Fixes for the Symfony profiler integration

### DIFF
--- a/Controller/PanelController.php
+++ b/Controller/PanelController.php
@@ -9,7 +9,8 @@
  */
 namespace Propel\Bundle\PropelBundle\Controller;
 
-use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -17,8 +18,10 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * @author William DURAND <william.durand1@gmail.com>
  */
-class PanelController extends ContainerAware
+class PanelController implements ContainerAwareInterface
 {
+    use ContainerAwareTrait;
+
     /**
      * This method renders the global Propel configuration.
      */

--- a/Resources/views/Collector/propel.html.twig
+++ b/Resources/views/Collector/propel.html.twig
@@ -79,12 +79,12 @@
                     <code>{{ query.sql|format_sql }}</code>
                     {% if app.request.query.has('query') and app.request.query.get('query') == i %}
                         <div class="SQLExplain">
-                        {% render controller('PropelBundle:Panel:explain', {
+                        {{ render(controller('PropelBundle:Panel:explain', {
                             'token': token,
                             'panel': 'propel',
                             'query': app.request.query.get('query'),
                             'connection': app.request.query.get('connection')
-                        }) %}
+                        })) }}
                         </div>
                     {% endif %}
                     <div class="SQLInfo">
@@ -101,5 +101,5 @@
         </tbody>
     </table>
 
-    {% render controller('PropelBundle:Panel:configuration') %}
+    {{ render(controller('PropelBundle:Panel:configuration')) }}
 {% endblock %}


### PR DESCRIPTION
- Updated PanelController to use Symfony's ContainerAwareTrait instead of the removed ContainerAware class.
- Fixed function syntax for rendering controllers within the Collector Twig template.

Will close #401.
