### PR TITLE
Fixed render tags for Symfony >=2.8

### DIFF
--- a/Resources/views/Collector/propel.html.twig
+++ b/Resources/views/Collector/propel.html.twig
@@ -115,12 +115,12 @@
                     <code>{{ query.sql|format_sql|raw }}</code>
                     {% if app.request.query.has('query') and app.request.query.get('query') == i %}
                         <div class="SQLExplain">
-                        {% render controller('PropelBundle:Panel:explain', {
+                        {{ render(controller('PropelBundle:Panel:explain', {
                             'token': token,
                             'panel': 'propel',
                             'query': app.request.query.get('query'),
                             'connection': app.request.query.get('connection')
-                        }) %}
+                        }))}}
                         </div>
                     {% endif %}
                     <div class="SQLInfo">
@@ -149,5 +149,5 @@
         </tbody>
     </table>
 
-    {% render controller('PropelBundle:Panel:configuration') %}
+    {{ render(controller('PropelBundle:Panel:configuration'))}}
 {% endblock %}


### PR DESCRIPTION
This one fixes `Symfony` profiler crash. I got it on 3.0.3, but I believe could be present in earlier versions of Symfony itself or version of Twig used by Symfony >= 2.8
