### PR TITLE
[3.0] fixed ModelType

### DIFF
--- a/Form/ChoiceList/PropelChoiceLoader.php
+++ b/Form/ChoiceList/PropelChoiceLoader.php
@@ -10,6 +10,7 @@
 
 namespace Propel\Bundle\PropelBundle\Form\ChoiceList;
 
+use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\ActiveQuery\ModelCriteria;
 use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
 use Propel\Runtime\Map\ColumnMap;
@@ -110,7 +111,8 @@ class PropelChoiceLoader implements ChoiceLoaderInterface
         // Optimize performance in case we have a single-field identifier
         if (!$this->choiceList && $this->identifierAsIndex && current($this->identifier) instanceof ColumnMap) {
             $phpName = current($this->identifier)->getPhpName();
-            $unorderedObjects = $this->query->filterBy($phpName, $values);
+            $query = clone $this->query;
+            $unorderedObjects = $query->filterBy($phpName, $values, Criteria::IN);
             $objectsById = array();
             $objects = array();
 


### PR DESCRIPTION
@IceShack thanks for the work in #403!

I tried to use PropelBundle with sf 3.0, but after sending a form all modeltypes are empty (no choices).
This is fixed now.
