### PR TITLE
remove the semicolon before dbname

### DIFF
--- a/Command/DatabaseCreateCommand.php
+++ b/Command/DatabaseCreateCommand.php
@@ -91,7 +91,7 @@ class DatabaseCreateCommand extends AbstractCommand
         $dbName = $this->parseDbName($config['dsn']);
 
         $config['dsn'] = preg_replace(
-            '#dbname='.$dbName.';?#',
+            '#;?dbname='.$dbName.';?#',
             '',
             $config['dsn']
         );


### PR DESCRIPTION
A dsn like `mysql:host=localhost;dbname=foo`
After `preg_replace`, the dsn become `mysql:host=localhost;`
If we have additional setting "charset: utf8", the dsn will become `mysql:host=localhost;;charset=utf8`, which makes `propel:database:create` command not working
