### PR TITLE
Fixed temporary configuration for database creation

### DIFF
--- a/Command/DatabaseCreateCommand.php
+++ b/Command/DatabaseCreateCommand.php
@@ -91,7 +91,7 @@ class DatabaseCreateCommand extends AbstractCommand
         $dbName = $this->parseDbName($config['dsn']);
 
         $config['dsn'] = preg_replace(
-            '#;?dbname='.$dbName.'?#',
+            '#;?dbname='.$dbName.'#',
             '',
             $config['dsn']
         );

--- a/Command/DatabaseCreateCommand.php
+++ b/Command/DatabaseCreateCommand.php
@@ -91,7 +91,7 @@ class DatabaseCreateCommand extends AbstractCommand
         $dbName = $this->parseDbName($config['dsn']);
 
         $config['dsn'] = preg_replace(
-            '#;?dbname='.$dbName.';?#',
+            '#;?dbname='.$dbName.'?#',
             '',
             $config['dsn']
         );


### PR DESCRIPTION
When you create the database via the Propel command propel:database:create you've to connect without the given database name from the configuration. Due this fact the DSN is modified to add the possibility to connect to the database. The problem is that after the database name the charset is appended and the result was like the following.

```
mysql:host=127.0.0.1charset=UTF8
```
