### PR TITLE
Added Identifier quoting

### DIFF
--- a/DataFixtures/Dumper/AbstractDataDumper.php
+++ b/DataFixtures/Dumper/AbstractDataDumper.php
@@ -107,7 +107,7 @@ abstract class AbstractDataDumper extends AbstractDataHandler implements DataDum
                 }
                 $stmt = $this
                     ->con
-                    ->query(sprintf('SELECT %s FROM %s', implode(',', $in), constant(constant($tableName.'::TABLE_MAP').'::TABLE_NAME')));
+                    ->query(sprintf('SELECT `%s` FROM `%s`', implode('`, `', $in), constant(constant($tableName.'::TABLE_MAP').'::TABLE_NAME')));
 
                 $set = array();
                 while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {


### PR DESCRIPTION
```
SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'order' at line 1
```

Query

```
SELECT id, ... FROM order
```
