### PR TITLE
Fixed temporaty connection

### DIFF
--- a/Command/DatabaseCreateCommand.php
+++ b/Command/DatabaseCreateCommand.php
@@ -90,11 +90,7 @@ class DatabaseCreateCommand extends AbstractCommand
     {
         $dbName = $this->parseDbName($config['dsn']);
 
-        $config['dsn'] = preg_replace(
-            '#;?dbname='.$dbName.'#',
-            '',
-            $config['dsn']
-        );
+        $config['dsn'] = str_replace('dbname='.$dbName.';', '', $config['dsn']);
 
         return $config;
     }


### PR DESCRIPTION
My dsn = "mysql:host=127.0.0.1;dbname=test;user=root;charset=utf8"
Temporary dsn  "mysql:host=127.0.0.1user=root;charset=utf8"

And I received error "PDO::__construct(): php_network_getaddresses: getaddrinfo failed: Name or service not known  "
because host equal "127.0.0.1user=roor"
