### PR TITLE
Set option "by_reference" to false (Change property not ObjectCollection)

### DIFF
--- a/Form/Type/ModelType.php
+++ b/Form/Type/ModelType.php
@@ -121,7 +121,6 @@ class ModelType extends AbstractType
     {
         if ($options['multiple']) {
             $builder
-            #    ->addEventSubscriber(new MergeDoctrineCollectionListener())
                 ->addViewTransformer(new CollectionToArrayTransformer(), true)
             ;
         }
@@ -233,6 +232,7 @@ class ModelType extends AbstractType
             'choice_name' => $choiceName,
             'choice_value' => $choiceValue,
             'choice_translation_domain' => false,
+            'by_reference' => false,
         ]);
 
         $resolver->setRequired(array('class'));


### PR DESCRIPTION
This is the fix for #423.

by_reference is set to true by default, so if you submit the form it will change the ObjectCollection, not the underlying property.
