### PR TITLE
fix symfony 2.8 deprecation warnings

### DIFF
--- a/Form/Type/ModelType.php
+++ b/Form/Type/ModelType.php
@@ -176,9 +176,9 @@ class ModelType extends AbstractType
             }
             /** @var ColumnMap $firstIdentifier */
             $firstIdentifier = current($identifier);
-            if (count($identifier) === 1 && in_array($firstIdentifier->getPdoType(), [\PDO::PARAM_BOOL, \PDO::PARAM_INT, \PDO::PARAM_STR])) {
+            if (count($identifier) === 1 && in_array($firstIdentifier->getPdoType(), array(\PDO::PARAM_BOOL, \PDO::PARAM_INT, \PDO::PARAM_STR))) {
                 return function($object) use ($firstIdentifier) {
-                    return call_user_func([$object, 'get' . ucfirst($firstIdentifier->getPhpName())]);
+                    return call_user_func(array($object, 'get' . ucfirst($firstIdentifier->getPhpName())));
                 };
             }
             return null;
@@ -214,7 +214,7 @@ class ModelType extends AbstractType
                     $getter = 'get' . ucfirst($query->getTableMap()->getColumn($valueProperty)->getPhpName());
 
                     $choiceLabel = function($choice) use ($getter) {
-                        return call_user_func([$choice, $getter]);
+                        return call_user_func(array($choice, $getter));
                     };
                 }
             }
@@ -222,7 +222,7 @@ class ModelType extends AbstractType
             return $choiceLabel;
         };
 
-        $resolver->setDefaults([
+        $resolver->setDefaults(array(
             'query' => null,
             'index_property' => null,
             'property' => null,
@@ -234,12 +234,12 @@ class ModelType extends AbstractType
             'choice_value' => $choiceValue,
             'choice_translation_domain' => false,
             'by_reference' => false,
-        ]);
+        ));
 
         $resolver->setRequired(array('class'));
         $resolver->setNormalizer('query', $queryNormalizer);
         $resolver->setNormalizer('choice_label', $choiceLabelNormalizer);
-        $resolver->setAllowedTypes('query', ['null', '\ModelCriteria']);
+        $resolver->setAllowedTypes('query', array('null', '\ModelCriteria'));
     }
 
     /**


### PR DESCRIPTION
Fix deprecation warnings in Symfony 2.8 when using ModelType

The value "false" for the "choices_as_values" option of the "choice" form type (Symfony\Component\Form\Extension\Core\Type\ChoiceType) is deprecated since version 2.8 and will not be supported anymore in 3.0. Set this option to "true" and flip the contents of the "choices" option instead

The "choice_list" option of the "choice" form type (Symfony\Component\Form\Extension\Core\Type\ChoiceType) is deprecated since version 2.7 and will be removed in 3.0. Use "choice_loader" instead

Propel\Bundle\PropelBundle\Form\Type\ModelType: The FormTypeInterface::getName() method is deprecated since version 2.8 and will be removed in 3.0. Remove it from your classes. Use getBlockPrefix() if you want to customize the template block prefix. This method will be added to the FormTypeInterface with Symfony 3.0

Accessing type "choice" by its string name is deprecated since version 2.8 and will be removed in 3.0. Use the fully-qualified type class name "Symfony\Component\Form\Extension\Core\Type\ChoiceType" instead

Fixes #394
