### PR TITLE
feat(DataLoader): allow to set foreign key for a table not included in fixture

### DIFF
--- a/Tests/DataFixtures/Loader/YamlDataLoaderTest.php
+++ b/Tests/DataFixtures/Loader/YamlDataLoaderTest.php
@@ -45,6 +45,32 @@ YAML;
         $this->assertInstanceOf('Propel\PropelBundle\Tests\Fixtures\DataFixtures\Loader\BookAuthor', $book->getBookAuthor());
     }
 
+    public function testYamlLoadOneToManyExternalReference()
+    {
+        $loader = new YamlDataLoader(__DIR__.'/../../Fixtures/DataFixtures/Loader');
+        $fixtures = <<<YAML
+\Propel\PropelBundle\Tests\Fixtures\DataFixtures\Loader\BookAuthor:
+    BookAuthor_1:
+        id: '1'
+        name: 'A famous one'
+YAML;
+        $filename = $this->getTempFile($fixtures);
+        $loader->load(array($filename), 'default');
+        $fixtures = <<<YAML
+\Propel\PropelBundle\Tests\Fixtures\DataFixtures\Loader\Book:
+    Book_1:
+        id: '1'
+        name: 'An important one'
+        author_id: 1
+YAML;
+        $filename = $this->getTempFile($fixtures);
+        $loader->load(array($filename), 'default');
+        $books = \Propel\PropelBundle\Tests\Fixtures\DataFixtures\Loader\BookQuery::create()->find($this->con);
+        $this->assertCount(1, $books);
+        $book = $books[0];
+        $this->assertInstanceOf('Propel\PropelBundle\Tests\Fixtures\DataFixtures\Loader\BookAuthor', $book->getBookAuthor());
+    }
+
     public function testYamlLoadManyToMany()
     {
         $schema = <<<XML


### PR DESCRIPTION
This allows to set foreign keys by using the id if the foreign table is not included in the given fixture files.

Backport of #345 for 1.4
