### PR TITLE
fixes panel when default connection is specified

### DIFF
--- a/Resources/views/Panel/configuration.html.twig
+++ b/Resources/views/Panel/configuration.html.twig
@@ -36,7 +36,7 @@
         </tr>
     </thead>
     <tbody>
-        {% for name, config in configuration.datasources %}
+        {% for name, config in configuration.datasources if config is iterable %}
         <tr>
             <th rowspan="5" style="vertical-align: top;">
                 {{ name }}


### PR DESCRIPTION
Impossible to access an attribute ("adapter") on a string variable... is thrown when default connection is defined, then config is a string name of that connection, not a configuration options
