### PR TITLE
Fix error on Form/Type/ModelType.php.

### DIFF
--- a/Form/Type/ModelType.php
+++ b/Form/Type/ModelType.php
@@ -91,7 +91,7 @@ class ModelType extends AbstractType
     {
         return (string) $choice;
     }
-    
+
     /**
      * Creates the field name for a choice.
      *
@@ -134,17 +134,17 @@ class ModelType extends AbstractType
         $choiceLoader = function (Options $options) {
             // Unless the choices are given explicitly, load them on demand
             if (null === $options['choices']) {
-                
+
                 $propelChoiceLoader = new PropelChoiceLoader(
                     $this->choiceListFactory,
                     $options['class'],
                     $options['query'],
                     $options['index_property']
                 );
-                
+
                 return $propelChoiceLoader;
             }
-            
+
             return null;
         };
 
@@ -178,12 +178,15 @@ class ModelType extends AbstractType
             $firstIdentifier = current($identifier);
             if (count($identifier) === 1 && in_array($firstIdentifier->getPdoType(), [\PDO::PARAM_BOOL, \PDO::PARAM_INT, \PDO::PARAM_STR])) {
                 return function($object) use ($firstIdentifier) {
-                    return call_user_func([$object, 'get' . ucfirst($firstIdentifier->getPhpName())]);
+                    if ($object) {
+                        return call_user_func([$object, 'get' . ucfirst($firstIdentifier->getPhpName())]);
+                    }
+                    return null;
                 };
             }
             return null;
         };
-        
+
         $queryNormalizer = function (Options $options, $query) {
             if ($query === null) {
                 $queryClass = $options['class'] . 'Query';
@@ -202,7 +205,7 @@ class ModelType extends AbstractType
             }
             return $query;
         };
-        
+
         $choiceLabelNormalizer = function (Options $options, $choiceLabel) {
             if ($choiceLabel === null) {
                 if ($options['property'] == null) {
@@ -212,16 +215,16 @@ class ModelType extends AbstractType
                     /** @var ModelCriteria $query */
                     $query = $options['query'];
                     $getter = 'get' . ucfirst($query->getTableMap()->getColumn($valueProperty)->getPhpName());
-                    
+
                     $choiceLabel = function($choice) use ($getter) {
                         return call_user_func([$choice, $getter]);
                     };
                 }
             }
-            
+
             return $choiceLabel;
         };
-        
+
         $resolver->setDefaults([
             'query' => null,
             'index_property' => null,


### PR DESCRIPTION
You cannot always expect $object to be defined. When it is not, then you obtain this error:

`Warning: call_user_func() expects parameter 1 to be a valid callback, first array member is not a valid class name or object`

So it is necessary to check that $object is defined in the function.

Example that produces the above error:

`MyObjectType.php`:

```
        $builder
            ->add('son', ModelType::class, [
                'label' => 'labels.title',
                'query' => MySonObjectQuery::create(),
                'expanded' => true,
                'class' => MySonObject::class,
                'constraints' => [
                    new NotBlank([
                        'message' => 'form.error.not_blank',
                    ]),
                ],
            ]);
```

Note: setting `'expanded' => false,` above will not produce the error.

`schema.yml`:

```
    <table name="my_object">
        <column name="id" type="INTEGER" required="true" primaryKey="true" autoIncrement="true" />
        <column name="son_id" type="INTEGER" size="10" required="true" />

        <foreign-key foreignTable="my_son_object" phpName="Son">
            <reference local="son_id" foreign="id" />
        </foreign-key>
    </table>

    <table name="my_son_object">
        <column name="id" type="INTEGER" required="true" primaryKey="true" autoIncrement="true" />
        <column name="name" type="VARCHAR" size="10" required="true" />
    </table>
```

Stacktrace:

```
[1] Symfony\Component\Debug\Exception\ContextErrorException: Warning: call_user_func() expects parameter 1 to be a valid callback, first array member is not a valid class name or object
    at n/a
        in /home/peter/io/symfony_base_project/vendor/propel/propel-bundle/Form/Type/ModelType.php line 181

    at Symfony\Component\Debug\ErrorHandler->handleError('2', 'call_user_func() expects parameter 1 to be a valid callback, first array member is not a valid class name or object', '/home/peter/io/symfony_base_project/vendor/propel/propel-bundle/Form/Type/ModelType.php', '181', array('object' => null, 'firstIdentifier' => object(ColumnMap)))
        in  line 

    at call_user_func(array(null, 'getId'))
        in /home/peter/io/symfony_base_project/vendor/propel/propel-bundle/Form/Type/ModelType.php line 181

    at Propel\Bundle\PropelBundle\Form\Type\ModelType->Propel\Bundle\PropelBundle\Form\Type\{closure}(null)
        in  line 

    at call_user_func(object(Closure), null)
        in /home/peter/io/symfony_base_project/vendor/symfony/symfony/src/Symfony/Component/Form/ChoiceList/ArrayChoiceList.php line 158

    at Symfony\Component\Form\ChoiceList\ArrayChoiceList->getValuesForChoices(array(null))
        in /home/peter/io/symfony_base_project/vendor/symfony/symfony/src/Symfony/Component/Form/ChoiceList/LazyChoiceList.php line 198

    at Symfony\Component\Form\ChoiceList\LazyChoiceList->getValuesForChoices(array(null))
        in /home/peter/io/symfony_base_project/vendor/symfony/symfony/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoiceToValueTransformer.php line 37

    at Symfony\Component\Form\Extension\Core\DataTransformer\ChoiceToValueTransformer->transform(null)
        in /home/peter/io/symfony_base_project/vendor/symfony/symfony/src/Symfony/Component/Form/Form.php line 1092

    at Symfony\Component\Form\Form->normToView(null)
        in /home/peter/io/symfony_base_project/vendor/symfony/symfony/src/Symfony/Component/Form/Form.php line 352

    at Symfony\Component\Form\Form->setData(null)
        in /home/peter/io/symfony_base_project/vendor/symfony/symfony/src/Symfony/Component/Form/Extension/Core/DataMapper/PropertyPathMapper.php line 57

    at Symfony\Component\Form\Extension\Core\DataMapper\PropertyPathMapper->mapDataToForms(object(MyObject), object(RecursiveIteratorIterator))
        in /home/peter/io/symfony_base_project/vendor/symfony/symfony/src/Symfony/Component/Form/Form.php line 385

    at Symfony\Component\Form\Form->setData(object(MyObject))
        in /home/peter/io/symfony_base_project/vendor/symfony/symfony/src/Symfony/Component/Form/Form.php line 477

    at Symfony\Component\Form\Form->initialize()
        in /home/peter/io/symfony_base_project/vendor/symfony/symfony/src/Symfony/Component/Form/FormBuilder.php line 226

    at Symfony\Component\Form\FormBuilder->getForm()
        in /home/peter/io/symfony_base_project/vendor/symfony/symfony/src/Symfony/Component/Form/FormFactory.php line 39

    at Symfony\Component\Form\FormFactory->create('AppBundle\Form\MyObjectType', object(MyObject), array('action' => '/app_dev.php/test'))
        in /home/peter/io/symfony_base_project/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php line 309

    at Symfony\Bundle\FrameworkBundle\Controller\Controller->createForm('AppBundle\Form\MyObjectType', object(MyObject), array('action' => '/app_dev.php/test'))
        in /home/peter/io/symfony_base_project/src/AdminBundle/Controller/DefaultController.php line 28

    at AdminBundle\Controller\DefaultController->testAction(object(Request))
        in  line 

    at call_user_func_array(array(object(DefaultController), 'testAction'), array(object(Request)))
        in /home/peter/io/symfony_base_project/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php line 153

    at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), '1')
        in /home/peter/io/symfony_base_project/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php line 68

    at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), '1', true)
        in /home/peter/io/symfony_base_project/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/Kernel.php line 169

    at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
        in /home/peter/io/symfony_base_project/web/app_dev.php line 30
```

I am using the latest versions of Symfony3 (3.1.3), Propel2 (8a25ecd369) and PropelBundle (ad4827d281).
