### PR TITLE
3.0 Some Fixes for MSSQL

### DIFF
--- a/Command/AbstractCommand.php
+++ b/Command/AbstractCommand.php
@@ -384,10 +384,10 @@ abstract class AbstractCommand extends ContainerAwareCommand
      */
     protected function parseDbName($dsn)
     {
-        preg_match('#dbname=([a-zA-Z0-9\_]+)#', $dsn, $matches);
+        preg_match('#(dbname|Database)=([a-zA-Z0-9\_]+)#', $dsn, $matches);
 
-        if (isset($matches[1])) {
-            return $matches[1];
+        if (isset($matches[2])) {
+            return $matches[2];
         }
 
         // e.g. SQLite

--- a/Command/DatabaseCreateCommand.php
+++ b/Command/DatabaseCreateCommand.php
@@ -83,7 +83,7 @@ class DatabaseCreateCommand extends AbstractCommand
         $dbName = $this->parseDbName($config['dsn']);
 
         $config['dsn'] = preg_replace(
-            '#;?dbname='.$dbName.'#',
+            '#;?(dbname|Database)='.$dbName.'#',
             '',
             $config['dsn']
         );

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -161,6 +161,7 @@ class Configuration extends PropelConfiguration
                                     	->addDefaultsIfNotSet()
                                         ->children()
                                             ->booleanNode('ATTR_EMULATE_PREPARES')->defaultFalse()->end()
+                                            ->scalarNode('SQLSRV_ATTR_ENCODING')->end()
                                         ->end()
                                     ->end()
                                     ->arrayNode('model_paths')


### PR DESCRIPTION
Hi,

Here is some fixes for MSSQL 
- Database instead of dbname because the DSN have to be %database_driver%:Server=%database_host%;Database=%database_name% for sqlserver
- And drop because if in mssql we not use a separate connection, will tell "Ressource is in used"
