### PR TITLE
Re-adds ModelType::getName(), broken in 0b31960

### DIFF
--- a/Form/Type/ModelType.php
+++ b/Form/Type/ModelType.php
@@ -245,6 +245,14 @@ class ModelType extends AbstractType
     /**
      * {@inheritdoc}
      */
+    public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getBlockPrefix()
     {
         return 'model';


### PR DESCRIPTION
Without this, ModelType is broken in symfony 2.8.