### PR TITLE
Fix profiler do not escape HTML for SQL query

### DIFF
--- a/Command/AbstractCommand.php
+++ b/Command/AbstractCommand.php
@@ -388,7 +388,7 @@ EOT
         <connection>
           <dsn>%dsn%</dsn>
           <user>%username%</user>
-          <password>%password%</password>
+          <password><![CDATA[%password%]]></password>
         </connection>
       </datasource>
 

--- a/Twig/Extension/SyntaxExtension.php
+++ b/Twig/Extension/SyntaxExtension.php
@@ -22,7 +22,7 @@ class SyntaxExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            new \Twig_SimpleFilter('format_sql', array($this, 'formatSQL', array('is_safe' => array('html')))),
+            new \Twig_SimpleFilter('format_sql', array($this, 'formatSQL'), array('is_safe' => array('html'))),
         );
     }
 


### PR DESCRIPTION
This fix an issue in the profiler where the html of SQL queries are escaped.