### PR TITLE
Fix inverted command verbosity for PropelBundle 1.4/1.5/1.6

### DIFF
--- a/Command/AbstractCommand.php
+++ b/Command/AbstractCommand.php
@@ -173,7 +173,7 @@ abstract class AbstractCommand extends ContainerAwareCommand
         // Add any arbitrary arguments last
         foreach ($this->additionalPhingArgs as $arg) {
             if (in_array($arg, array('verbose', 'debug'))) {
-                $bufferPhingOutput = false;
+                $bufferPhingOutput = true;
             }
 
             $args[] = '-'.$arg;
@@ -208,7 +208,7 @@ abstract class AbstractCommand extends ContainerAwareCommand
             $returnStatus = false;
         }
 
-        if ($bufferPhingOutput) {
+        if ($bufferPhingOutput === false) {
             ob_end_clean();
         } else {
             ob_end_flush();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 1.4/1.5/1.6
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | possibly (if users rely on the incorrect behaviour)
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT

For the 1.x branches of PropelBundle, the verbosity is apparently inverted to the expected behaviour.

$bufferPhingOutput is initially set to Symfony's kernel.debug parameter.
However, the conditional for checking the buffer works the other way round:
If buffering is enabled, the buffer is discarded, otherwise it is output.

This commit fixes that issue. Now if $bufferPhingOutput is true,
the detailed output of the command is displayed.