### PR TITLE
Fix deprecation issues raised by PropelTypeGuesser

### DIFF
--- a/Form/PropelTypeGuesser.php
+++ b/Form/PropelTypeGuesser.php
@@ -31,27 +31,27 @@ class PropelTypeGuesser implements FormTypeGuesserInterface
     public function guessType($class, $property)
     {
         if (!$table = $this->getTable($class)) {
-            return new TypeGuess('text', array(), Guess::LOW_CONFIDENCE);
+            return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\TextType', array(), Guess::LOW_CONFIDENCE);
         }
 
         foreach ($table->getRelations() as $relation) {
             if ($relation->getType() === \RelationMap::MANY_TO_ONE) {
                 if (strtolower($property) === strtolower($relation->getName())) {
-                    return new TypeGuess('model', array(
+                    return new TypeGuess('Propel\Bundle\PropelBundle\Form\Type\ModelType', array(
                         'class' => $relation->getForeignTable()->getClassName(),
                         'multiple' => false,
                     ), Guess::HIGH_CONFIDENCE);
                 }
             } elseif ($relation->getType() === \RelationMap::ONE_TO_MANY) {
                 if (strtolower($property) === strtolower($relation->getPluralName())) {
-                    return new TypeGuess('model', array(
+                    return new TypeGuess('Propel\Bundle\PropelBundle\Form\Type\ModelType', array(
                         'class' => $relation->getForeignTable()->getClassName(),
                         'multiple' => true,
                     ), Guess::HIGH_CONFIDENCE);
                 }
             } elseif ($relation->getType() === \RelationMap::MANY_TO_MANY) {
                 if (strtolower($property) == strtolower($relation->getPluralName())) {
-                    return new TypeGuess('model', array(
+                    return new TypeGuess('Propel\Bundle\PropelBundle\Form\Type\ModelType', array(
                         'class' => $relation->getLocalTable()->getClassName(),
                         'multiple' => true,
                     ), Guess::HIGH_CONFIDENCE);
@@ -60,32 +60,32 @@ class PropelTypeGuesser implements FormTypeGuesserInterface
         }
 
         if (!$column = $this->getColumn($class, $property)) {
-            return new TypeGuess('text', array(), Guess::LOW_CONFIDENCE);
+            return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\TextType', array(), Guess::LOW_CONFIDENCE);
         }
 
         switch ($column->getType()) {
             case \PropelColumnTypes::BOOLEAN:
             case \PropelColumnTypes::BOOLEAN_EMU:
-                return new TypeGuess('checkbox', array(), Guess::HIGH_CONFIDENCE);
+                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\CheckboxType', array(), Guess::HIGH_CONFIDENCE);
             case \PropelColumnTypes::TIMESTAMP:
             case \PropelColumnTypes::BU_TIMESTAMP:
-                return new TypeGuess('datetime', array(), Guess::HIGH_CONFIDENCE);
+                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\DateTimeType', array(), Guess::HIGH_CONFIDENCE);
             case \PropelColumnTypes::DATE:
             case \PropelColumnTypes::BU_DATE:
-                return new TypeGuess('date', array(), Guess::HIGH_CONFIDENCE);
+                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\DateType', array(), Guess::HIGH_CONFIDENCE);
             case \PropelColumnTypes::TIME:
-                return new TypeGuess('time', array(), Guess::HIGH_CONFIDENCE);
+                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\TimeType', array(), Guess::HIGH_CONFIDENCE);
             case \PropelColumnTypes::FLOAT:
             case \PropelColumnTypes::REAL:
             case \PropelColumnTypes::DOUBLE:
             case \PropelColumnTypes::DECIMAL:
-                return new TypeGuess('number', array(), Guess::MEDIUM_CONFIDENCE);
+                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\NumberType', array(), Guess::MEDIUM_CONFIDENCE);
             case \PropelColumnTypes::TINYINT:
             case \PropelColumnTypes::SMALLINT:
             case \PropelColumnTypes::INTEGER:
             case \PropelColumnTypes::BIGINT:
             case \PropelColumnTypes::NUMERIC:
-                return new TypeGuess('integer', array(), Guess::MEDIUM_CONFIDENCE);
+                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\IntegerType', array(), Guess::MEDIUM_CONFIDENCE);
             case \PropelColumnTypes::ENUM:
             case \PropelColumnTypes::CHAR:
                 if ($column->getValueSet()) {
@@ -93,17 +93,17 @@ class PropelTypeGuesser implements FormTypeGuesserInterface
                     $choices = $column->getValueSet();
                     $labels = array_map('ucfirst', $choices);
 
-                    return new TypeGuess('choice', array('choices' => array_combine($choices, $labels)), Guess::MEDIUM_CONFIDENCE);
+                    return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\ChoiceType', array('choices' => array_combine($labels, $choices), 'choices_as_values' => true), Guess::MEDIUM_CONFIDENCE);
                 }
             case \PropelColumnTypes::VARCHAR:
-                return new TypeGuess('text', array(), Guess::MEDIUM_CONFIDENCE);
+                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\TextType', array(), Guess::MEDIUM_CONFIDENCE);
             case \PropelColumnTypes::LONGVARCHAR:
             case \PropelColumnTypes::BLOB:
             case \PropelColumnTypes::CLOB:
             case \PropelColumnTypes::CLOB_EMU:
-                return new TypeGuess('textarea', array(), Guess::MEDIUM_CONFIDENCE);
+                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\TextareaType', array(), Guess::MEDIUM_CONFIDENCE);
             default:
-                return new TypeGuess('text', array(), Guess::LOW_CONFIDENCE);
+                return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\TextType', array(), Guess::LOW_CONFIDENCE);
         }
     }
 

--- a/Form/Type/ModelType.php
+++ b/Form/Type/ModelType.php
@@ -176,9 +176,9 @@ class ModelType extends AbstractType
             }
             /** @var ColumnMap $firstIdentifier */
             $firstIdentifier = current($identifier);
-            if (count($identifier) === 1 && in_array($firstIdentifier->getPdoType(), [\PDO::PARAM_BOOL, \PDO::PARAM_INT, \PDO::PARAM_STR])) {
+            if (count($identifier) === 1 && in_array($firstIdentifier->getPdoType(), array(\PDO::PARAM_BOOL, \PDO::PARAM_INT, \PDO::PARAM_STR))) {
                 return function($object) use ($firstIdentifier) {
-                    return call_user_func([$object, 'get' . ucfirst($firstIdentifier->getPhpName())]);
+                    return call_user_func(array($object, 'get' . ucfirst($firstIdentifier->getPhpName())));
                 };
             }
             return null;
@@ -214,7 +214,7 @@ class ModelType extends AbstractType
                     $getter = 'get' . ucfirst($query->getTableMap()->getColumn($valueProperty)->getPhpName());
 
                     $choiceLabel = function($choice) use ($getter) {
-                        return call_user_func([$choice, $getter]);
+                        return call_user_func(array($choice, $getter));
                     };
                 }
             }
@@ -222,7 +222,7 @@ class ModelType extends AbstractType
             return $choiceLabel;
         };
 
-        $resolver->setDefaults([
+        $resolver->setDefaults(array(
             'query' => null,
             'index_property' => null,
             'property' => null,
@@ -234,12 +234,12 @@ class ModelType extends AbstractType
             'choice_value' => $choiceValue,
             'choice_translation_domain' => false,
             'by_reference' => false,
-        ]);
+        ));
 
         $resolver->setRequired(array('class'));
         $resolver->setNormalizer('query', $queryNormalizer);
         $resolver->setNormalizer('choice_label', $choiceLabelNormalizer);
-        $resolver->setAllowedTypes('query', ['null', '\ModelCriteria']);
+        $resolver->setAllowedTypes('query', array('null', '\ModelCriteria'));
     }
 
     /**

--- a/Tests/Form/PropelTypeGuesserTest.php
+++ b/Tests/Form/PropelTypeGuesserTest.php
@@ -84,7 +84,7 @@ class PropelTypeGuesserTest extends TestCase
         $value = $this->guesser->guessType(self::UNKNOWN_CLASS_NAME, 'property');
 
         $this->assertNotNull($value);
-        $this->assertEquals('text', $value->getType());
+        $this->assertEquals('Symfony\Component\Form\Extension\Core\Type\TextType', $value->getType());
         $this->assertEquals(Guess::LOW_CONFIDENCE, $value->getConfidence());
     }
 
@@ -93,7 +93,7 @@ class PropelTypeGuesserTest extends TestCase
         $value = $this->guesser->guessType(self::CLASS_NAME, 'property');
 
         $this->assertNotNull($value);
-        $this->assertEquals('text', $value->getType());
+        $this->assertEquals('Symfony\Component\Form\Extension\Core\Type\TextType', $value->getType());
         $this->assertEquals(Guess::LOW_CONFIDENCE, $value->getConfidence());
     }
 
@@ -108,7 +108,7 @@ class PropelTypeGuesserTest extends TestCase
         $this->assertEquals($type, $value->getType());
         $this->assertEquals($confidence, $value->getConfidence());
 
-        if ($type === 'model') {
+        if ($type === 'Propel\Bundle\PropelBundle\Form\Type\ModelType') {
             $options = $value->getOptions();
 
             $this->assertSame($multiple, $options['multiple']);
@@ -118,19 +118,19 @@ class PropelTypeGuesserTest extends TestCase
     public static function dataProviderForGuessType()
     {
         return array(
-            array('is_active',  'checkbox', Guess::HIGH_CONFIDENCE),
-            array('enabled',    'checkbox', Guess::HIGH_CONFIDENCE),
-            array('id',         'integer',  Guess::MEDIUM_CONFIDENCE),
-            array('value',      'text',     Guess::MEDIUM_CONFIDENCE),
-            array('price',      'number',   Guess::MEDIUM_CONFIDENCE),
-            array('updated_at', 'datetime', Guess::HIGH_CONFIDENCE),
+            array('is_active',  'Symfony\Component\Form\Extension\Core\Type\CheckboxType', Guess::HIGH_CONFIDENCE),
+            array('enabled',    'Symfony\Component\Form\Extension\Core\Type\CheckboxType', Guess::HIGH_CONFIDENCE),
+            array('id',         'Symfony\Component\Form\Extension\Core\Type\IntegerType',  Guess::MEDIUM_CONFIDENCE),
+            array('value',      'Symfony\Component\Form\Extension\Core\Type\TextType',     Guess::MEDIUM_CONFIDENCE),
+            array('price',      'Symfony\Component\Form\Extension\Core\Type\NumberType',   Guess::MEDIUM_CONFIDENCE),
+            array('updated_at', 'Symfony\Component\Form\Extension\Core\Type\DateTimeType', Guess::HIGH_CONFIDENCE),
 
-            array('isActive',   'checkbox', Guess::HIGH_CONFIDENCE),
-            array('updatedAt',  'datetime', Guess::HIGH_CONFIDENCE),
+            array('isActive',   'Symfony\Component\Form\Extension\Core\Type\CheckboxType', Guess::HIGH_CONFIDENCE),
+            array('updatedAt',  'Symfony\Component\Form\Extension\Core\Type\DateTimeType', Guess::HIGH_CONFIDENCE),
 
-            array('Authors',    'model',    Guess::HIGH_CONFIDENCE,     true),
-            array('Resellers',  'model',    Guess::HIGH_CONFIDENCE,     true),
-            array('MainAuthor', 'model',    Guess::HIGH_CONFIDENCE,     false),
+            array('Authors',    'Propel\Bundle\PropelBundle\Form\Type\ModelType',    Guess::HIGH_CONFIDENCE,     true),
+            array('Resellers',  'Propel\Bundle\PropelBundle\Form\Type\ModelType',    Guess::HIGH_CONFIDENCE,     true),
+            array('MainAuthor', 'Propel\Bundle\PropelBundle\Form\Type\ModelType',    Guess::HIGH_CONFIDENCE,     false),
         );
     }
 }


### PR DESCRIPTION
I've replaced the type names with the FQCN's as suggested in https://github.com/symfony/symfony/blob/2.8/UPGRADE-2.8.md#form, but didn't use the class constants, since Symfony 2.8 also targets PHP versions before 5.5.

I've also flipped the choices-array as suggested in https://github.com/symfony/symfony/blob/2.8/UPGRADE-2.7.md#form when the column type is ENUM