### PR TITLE
do not require full symfony/symfony package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,9 @@
 
     "require": {
         "propel/propel": "dev-master",
-        "symfony/symfony": "^2.8|^3.0",
+        "symfony/console": "^2.8|^3.0",
+        "symfony/dependency-injection": "^2.8|^3.0",
+        "symfony/framework-bundle": "^2.8|^3.0",
         "symfony/security-acl": "^2.8|^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
This is a first step to make this bundle compatible to the new symfony skeleton (symfony flex), which [conflicts with symfony/symfony](https://github.com/symfony/skeleton/blob/5a78a7dec6f271ff301ce48a60bc6eff5d11c8bf/composer.json#L42).
