### PR TITLE
support bundle-less schema file

### DIFF
--- a/Resources/config/propel.xml
+++ b/Resources/config/propel.xml
@@ -21,6 +21,7 @@
     <services>
         <service id="propel.schema_locator" class="%propel.schema_locator.class%">
             <argument type="service" id="file_locator" />
+            <argument>%propel.configuration%</argument>
         </service>
 
         <service id="propel.logger" class="%propel.logger.class%">

--- a/Service/SchemaLocator.php
+++ b/Service/SchemaLocator.php
@@ -17,10 +17,25 @@ use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 class SchemaLocator
 {
     protected $fileLocator;
+    protected $configuration;
 
-    public function __construct(FileLocatorInterface $fileLocator)
+    public function __construct(FileLocatorInterface $fileLocator, array $configuration)
     {
         $this->fileLocator = $fileLocator;
+        $this->configuration = $configuration;
+    }
+
+    public function locateFromBundlesAndConfiguration(array $bundles)
+    {
+        $schemas = $this->locateFromBundles($bundles);
+
+        $path = $this->configuration['paths']['schemaDir'].'/schema.xml';
+        if (file_exists($path)) {
+            $schema = new \SplFileInfo($path);
+            $schemas[(string) $schema] = array(null, $schema);
+        }
+
+        return $schemas;
     }
 
     public function locateFromBundles(array $bundles)


### PR DESCRIPTION
With symfony/flex you create usually bundle-less applications.
With this PR the propel-bundle also looks in configured `schemaDir` for a schema file.

But I'm not sure if it is the best way to solve this.

closes #330, closes #446