### PR TITLE
Allow to configure sql/migrations dir

### DIFF
--- a/Command/MigrationDiffCommand.php
+++ b/Command/MigrationDiffCommand.php
@@ -54,7 +54,7 @@ class MigrationDiffCommand extends WrappedCommand
      */
     protected function getSubCommandArguments(InputInterface $input)
     {
-        $defaultOutputDir = $this->getApplication()->getKernel()->getRootDir().'/propel/migrations';
+        $defaultOutputDir = $this->getContainer()->getParameter('propel.configuration')['paths']['migrationDir'];
 
         return array(
             '--connection'          => $this->getConnections($input->getOption('connection')),

--- a/Command/MigrationDownCommand.php
+++ b/Command/MigrationDownCommand.php
@@ -52,7 +52,7 @@ class MigrationDownCommand extends WrappedCommand
      */
     protected function getSubCommandArguments(InputInterface $input)
     {
-        $defaultOutputDir = $this->getApplication()->getKernel()->getRootDir().'/propel/migrations';
+        $defaultOutputDir = $this->getContainer()->getParameter('propel.configuration')['paths']['migrationDir'];
 
         return array(
             '--connection'      => $this->getConnections($input->getOption('connection')),

--- a/Command/MigrationMigrateCommand.php
+++ b/Command/MigrationMigrateCommand.php
@@ -52,7 +52,7 @@ class MigrationMigrateCommand extends WrappedCommand
      */
     protected function getSubCommandArguments(InputInterface $input)
     {
-        $defaultOutputDir = $this->getApplication()->getKernel()->getRootDir().'/propel/migrations';
+        $defaultOutputDir = $this->getContainer()->getParameter('propel.configuration')['paths']['migrationDir'];
 
         return array(
             '--connection'      => $this->getConnections($input->getOption('connection')),

--- a/Command/MigrationStatusCommand.php
+++ b/Command/MigrationStatusCommand.php
@@ -50,7 +50,7 @@ class MigrationStatusCommand extends WrappedCommand
      */
     protected function getSubCommandArguments(InputInterface $input)
     {
-        $defaultOutputDir = $this->getApplication()->getKernel()->getRootDir().'/propel/migrations';
+        $defaultOutputDir = $this->getContainer()->getParameter('propel.configuration')['paths']['migrationDir'];
 
         return array(
             '--connection'      => $this->getConnections($input->getOption('connection')),

--- a/Command/MigrationUpCommand.php
+++ b/Command/MigrationUpCommand.php
@@ -52,7 +52,7 @@ class MigrationUpCommand extends WrappedCommand
      */
     protected function getSubCommandArguments(InputInterface $input)
     {
-        $defaultOutputDir = $this->getApplication()->getKernel()->getRootDir().'/propel/migrations';
+        $defaultOutputDir = $this->getContainer()->getParameter('propel.configuration')['paths']['migrationDir'];
 
         return array(
             '--connection'      => $this->getConnections($input->getOption('connection')),

--- a/Command/SqlBuildCommand.php
+++ b/Command/SqlBuildCommand.php
@@ -47,7 +47,7 @@ class SqlBuildCommand extends WrappedCommand
      */
     protected function getSubCommandArguments(InputInterface $input)
     {
-        $defaultSqlDir = sprintf('%s/propel/sql', $this->getApplication()->getKernel()->getRootDir());
+        $defaultSqlDir = $this->getContainer()->getParameter('propel.configuration')['paths']['sqlDir'];
 
         return array(
             '--connection'  => $this->getConnections($input->getOption('connection')),

--- a/Command/SqlInsertCommand.php
+++ b/Command/SqlInsertCommand.php
@@ -59,7 +59,7 @@ class SqlInsertCommand extends WrappedCommand
      */
     protected function getSubCommandArguments(InputInterface $input)
     {
-        $defaultSqlDir = sprintf('%s/propel/sql', $this->getApplication()->getKernel()->getRootDir());
+        $defaultSqlDir = $this->getContainer()->getParameter('propel.configuration')['paths']['sqlDir'];
 
         return array(
             '--connection'  => $this->getConnections($input->getOption('connection')),

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -19,10 +19,29 @@ use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 class Configuration extends PropelConfiguration
 {
     private $debug;
+    private $defaultDir;
 
-    public function __construct($debug = true)
+    public function __construct($debug, $kernelDir)
     {
         $this->debug = $debug;
+        $this->defaultDir = $kernelDir.'/propel';
+    }
+
+    protected function addPathsSection(ArrayNodeDefinition $node)
+    {
+        $node
+            ->children()
+                ->arrayNode('paths')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('schemaDir')->defaultValue($this->defaultDir)->end()
+                        ->scalarNode('sqlDir')->defaultValue($this->defaultDir.'/sql')->end()
+                        ->scalarNode('migrationDir')->defaultValue($this->defaultDir.'/migrations')->end()
+                        ->scalarNode('composerDir')->defaultNull()->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
     }
 
     protected function addRuntimeSection(ArrayNodeDefinition $node)

--- a/DependencyInjection/PropelExtension.php
+++ b/DependencyInjection/PropelExtension.php
@@ -60,7 +60,7 @@ class PropelExtension extends Extension
 
     public function getConfiguration(array $config, ContainerBuilder $container)
     {
-        return new Configuration($container->getParameter('kernel.debug'));
+        return new Configuration($container->getParameter('kernel.debug'), $container->getParameter('kernel.root_dir'));
     }
 
     /**


### PR DESCRIPTION
With symfony/flex the `kernel.root_dir` changed from `/app` to `/src`.
Before this pr the paths to sql and migrations files were hardcoded to `%kernel.root_dir%/propel/{sql,migrations}`.
So with symfony flex this would be `/src/propel/...`.
But I do not want to place the sql and migration files in `src`.

With this pr the paths are configurable (but they default to the same paths as before).

Example for a custom configuration:

```yaml
propel:
    paths:
        schemaDir: '%kernel.project_dir%/database'
        sqlDir: '%kernel.project_dir%/database/sql'
        migrationDir: '%kernel.project_dir%/database/migrations'
```

(`%kernel.project_dir%` is new in sf 3.3)