### PR TITLE
[1.4] fix tests with php 5.3, add build with php 7.1 / 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,38 +1,44 @@
 language: php
 
 php:
-    - 5.3
-    - 5.4
-    - 5.5
     - 5.6
     - 7.0
+    - 7.1
+    - 7.2
     - hhvm
+
+cache:
+    directories:
+      - $HOME/.composer/cache/files
 
 env:
     - SYMFONY_VERSION="~2.4.0"
     - SYMFONY_VERSION="~2.5.0"
     - SYMFONY_VERSION="~2.6.0"
     - SYMFONY_VERSION="~2.7.0"
-    - SYMFONY_VERSION="dev-master"
 
 matrix:
     fast_finish: true
     allow_failures:
-        - php: 7.0
+        - php: 7.2
         - php: hhvm
-        - env: SYMFONY_VERSION="dev-master"
-    exclude:
-        # Symfony 3.x requires PHP 5.5
+    include:
         - php: 5.3
-          env: SYMFONY_VERSION="dev-master"
+          dist: precise
+          env: SYMFONY_VERSION="~2.7.0"
         - php: 5.4
-          env: SYMFONY_VERSION="dev-master"
+          env: SYMFONY_VERSION="~2.7.0"
+        - php: 5.5
+          env: SYMFONY_VERSION="~2.7.0"
 
 sudo: false
 
-before_script:
-  - curl -s http://getcomposer.org/installer | php
-  - php composer.phar require --no-update symfony/symfony:${SYMFONY_VERSION}
-  - php composer.phar install --prefer-source
+before_install:
+  - if [ "$TRAVIS_PHP_VERSION" == "5.3" ]; then phpenv config-add travis.php.ini; fi
+  - if [ "$TRAVIS_PHP_VERSION" == "5.3" ]; then phpenv config-rm xdebug.ini; fi
+  - composer require --no-update symfony/symfony:${SYMFONY_VERSION}
 
-script: phpunit --coverage-text
+install:
+  - composer install --prefer-source
+
+script: vendor/bin/phpunit --colors

--- a/Tests/DataFixtures/Dumper/YamlDataDumperTest.php
+++ b/Tests/DataFixtures/Dumper/YamlDataDumperTest.php
@@ -12,6 +12,7 @@ namespace Propel\PropelBundle\Tests\DataFixtures\Dumper;
 
 use Propel\PropelBundle\Tests\DataFixtures\TestCase;
 use Propel\PropelBundle\DataFixtures\Dumper\YamlDataDumper;
+use Symfony\Component\Config\Loader\LoaderInterface;
 
 /**
  * @author William Durand <william.durand1@gmail.com>
@@ -40,7 +41,16 @@ class YamlDataDumperTest extends TestCase
         $loader = new YamlDataDumper(__DIR__.'/../../Fixtures/DataFixtures/Loader');
         $loader->dump($filename);
 
-        $expected = <<<YAML
+        $expected = $this->getYamlForSymfonyVersion();
+
+        $result = file_get_contents($filename);
+        $this->assertEquals($expected, $result);
+    }
+
+    protected function getYamlForSymfonyVersion()
+    {
+        if (version_compare(AppKernel::VERSION, '2.7.0', '<')) {
+            return <<<YAML
 Propel\PropelBundle\Tests\Fixtures\DataFixtures\Loader\BookAuthor:
     BookAuthor_1:
         id: '1'
@@ -53,8 +63,34 @@ Propel\PropelBundle\Tests\Fixtures\DataFixtures\Loader\Book:
         complementary_infos: !!php/object:O:8:"stdClass":1:{s:15:"first_word_date";s:10:"2012-01-01";}
 
 YAML;
+        }
 
-        $result = file_get_contents($filename);
-        $this->assertEquals($expected, $result);
+        return <<<YAML
+Propel\PropelBundle\Tests\Fixtures\DataFixtures\Loader\BookAuthor:
+    BookAuthor_1:
+        id: '1'
+        name: 'A famous one'
+Propel\PropelBundle\Tests\Fixtures\DataFixtures\Loader\Book:
+    Book_1:
+        id: '1'
+        name: 'An important one'
+        author_id: BookAuthor_1
+        complementary_infos: !php/object:O:8:"stdClass":1:{s:15:"first_word_date";s:10:"2012-01-01";}
+
+YAML;
     }
+}
+
+class AppKernel extends \Symfony\Component\HttpKernel\Kernel
+{
+    public function registerBundles()
+    {
+        // TODO: Implement registerBundles() method.
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        // TODO: Implement registerContainerConfiguration() method.
+    }
+
 }

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
     "propel/propel1": "~1.6"
   },
   "require-dev": {
+    "phpunit/phpunit": "^4.8.21|^5.0.10",
     "sensio/framework-extra-bundle": "~3.0",
-    "fzaninotto/faker": "dev-master"
+    "fzaninotto/faker": "^1.5"
   },
   "autoload": {
     "psr-0": { "Propel\\PropelBundle": "" }
   },
-  "target-dir": "Propel/PropelBundle",
-  "minimum-stability": "dev"
+  "target-dir": "Propel/PropelBundle"
 }

--- a/travis.php.ini
+++ b/travis.php.ini
@@ -1,0 +1,1 @@
+memory_limit = 4G


### PR DESCRIPTION
This fix memory limit issue with php 5.3 tests

This also fix a broken test with Symfony 2.7 related to a change in Yaml dumper