### PR TITLE
Symfony 4.0 updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ sudo: false
 language: php
 
 php:
-    - 5.5
-    - 5.6
     - 7.0
     - 7.1
     - 7.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,26 +12,15 @@ cache:
         - $HOME/.composer/cache/files
 
 env:
-    - SYMFONY_VERSION="^2.8"
-    - SYMFONY_VERSION="^2.8" COMPOSER_FLAGS="--prefer-lowest"
     - SYMFONY_VERSION="^3.0"
-    - SYMFONY_VERSION="^3.0" COMPOSER_FLAGS="--prefer-lowest"
     - SYMFONY_VERSION="^4.0"
 
 matrix:
     fast_finish: true
 
     exclude:
-        - php: 5.5
-          env: SYMFONY_VERSION="^4.0"
-        - php: 5.6
-          env: SYMFONY_VERSION="^4.0"
         - php: 7.0
           env: SYMFONY_VERSION="^4.0"
-        - php: 7.2
-          env: SYMFONY_VERSION="^2.8"
-        - php: 7.2
-          env: SYMFONY_VERSION="^2.8" COMPOSER_FLAGS="--prefer-lowest"
 
 before_install:
     - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ php:
     - 7.0
     - 7.1
     - 7.2
-    - nightly
 
 cache:
     directories:
@@ -19,22 +18,18 @@ env:
     - SYMFONY_VERSION="^2.8" COMPOSER_FLAGS="--prefer-lowest"
     - SYMFONY_VERSION="^3.0"
     - SYMFONY_VERSION="^3.0" COMPOSER_FLAGS="--prefer-lowest"
-    - SYMFONY_VERSION="dev-master"
-    - SYMFONY_VERSION="^4.0" DEPENDENCIES=beta
+    - SYMFONY_VERSION="^4.0"
 
 matrix:
     fast_finish: true
 
-    allow_failures:
-        - php: nightly
-
     exclude:
         - php: 5.5
-          env: SYMFONY_VERSION="^4.0" DEPENDENCIES=beta
+          env: SYMFONY_VERSION="^4.0"
         - php: 5.6
-          env: SYMFONY_VERSION="^4.0" DEPENDENCIES=beta
+          env: SYMFONY_VERSION="^4.0"
         - php: 7.0
-          env: SYMFONY_VERSION="^4.0" DEPENDENCIES=beta
+          env: SYMFONY_VERSION="^4.0"
         - php: 7.2
           env: SYMFONY_VERSION="^2.8"
         - php: 7.2
@@ -42,7 +37,6 @@ matrix:
 
 before_install:
     - composer self-update
-    - if [ "$DEPENDENCIES" = "beta" ]; then composer config minimum-stability beta; fi;
     - if [ "${SYMFONY_VERSION}" != "" ]; then composer require --no-update "symfony/symfony:${SYMFONY_VERSION}"; fi;
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ php:
     - 5.5
     - 5.6
     - 7.0
+    - 7.1
+    - 7.2
     - nightly
     - hhvm
 
@@ -19,6 +21,7 @@ env:
     - SYMFONY_VERSION="^3.0"
     - SYMFONY_VERSION="^3.0" COMPOSER_FLAGS="--prefer-lowest"
     - SYMFONY_VERSION="dev-master"
+    - SYMFONY_VERSION="^4.0" DEPENDENCIES=beta
 
 matrix:
     fast_finish: true
@@ -28,9 +31,22 @@ matrix:
         - php: nightly
         - env: SYMFONY_VERSION="dev-master"
 
+    exclude:
+        - php: 5.5
+          env: SYMFONY_VERSION="^4.0" DEPENDENCIES=beta
+        - php: 5.6
+          env: SYMFONY_VERSION="^4.0" DEPENDENCIES=beta
+        - php: 7.0
+          env: SYMFONY_VERSION="^4.0" DEPENDENCIES=beta
+        - php: 7.2
+          env: SYMFONY_VERSION="^2.8"
+        - php: 7.2
+          env: SYMFONY_VERSION="^2.8" COMPOSER_FLAGS="--prefer-lowest"
+
 before_install:
     - phpenv config-rm xdebug.ini
     - composer self-update
+    - if [ "$DEPENDENCIES" = "beta" ]; then composer config minimum-stability beta; fi;
     - if [ "${SYMFONY_VERSION}" != "" ]; then composer require --no-update "symfony/symfony:${SYMFONY_VERSION}"; fi;
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,35 +3,22 @@ sudo: false
 language: php
 
 php:
-    - 5.5
-    - 5.6
-    - 7.0
+    - 7.1
+    - 7.2
     - nightly
-    - hhvm
 
 cache:
     directories:
         - $HOME/.composer/cache/files
 
-env:
-    - SYMFONY_VERSION="^2.8"
-    - SYMFONY_VERSION="^2.8" COMPOSER_FLAGS="--prefer-lowest"
-    - SYMFONY_VERSION="^3.0"
-    - SYMFONY_VERSION="^3.0" COMPOSER_FLAGS="--prefer-lowest"
-    - SYMFONY_VERSION="dev-master"
-
 matrix:
     fast_finish: true
 
     allow_failures:
-        - php: hhvm
         - php: nightly
-        - env: SYMFONY_VERSION="dev-master"
 
 before_install:
-    - phpenv config-rm xdebug.ini
     - composer self-update
-    - if [ "${SYMFONY_VERSION}" != "" ]; then composer require --no-update "symfony/symfony:${SYMFONY_VERSION}"; fi;
 
 install:
     - composer update ${COMPOSER_FLAGS} --prefer-source

--- a/Command/AbstractCommand.php
+++ b/Command/AbstractCommand.php
@@ -169,18 +169,18 @@ abstract class AbstractCommand extends ContainerAwareCommand
      * Return a list of final schema files that will be processed.
      *
      * @param KernelInterface $kernel The application kernel.
-     * @param bool $projectOnly If given, only the project schemas will
+     * @param BundleInterface $bundle If given, only the bundle's schemas will
      *                                be returned.
      *
      * @return array A list of schemas.
      */
-    protected function getFinalSchemas(KernelInterface $kernel, $projectOnly = false)
+    protected function getFinalSchemas(KernelInterface $kernel, BundleInterface $bundle = null)
     {
-        if (true === $projectOnly) {
-            return $this->getSchemaLocator()->locateFromProject($kernel);
+        if (null !== $bundle) {
+            return $this->getSchemaLocator()->locateFromBundle($bundle);
         }
 
-        return $this->getSchemaLocator()->locateFromProjectAndConfiguration($kernel);
+        return $this->getSchemaLocator()->locateFromBundlesAndConfiguration($kernel->getBundles());
     }
 
     /**

--- a/Command/AbstractCommand.php
+++ b/Command/AbstractCommand.php
@@ -169,18 +169,18 @@ abstract class AbstractCommand extends ContainerAwareCommand
      * Return a list of final schema files that will be processed.
      *
      * @param KernelInterface $kernel The application kernel.
-     * @param BundleInterface $bundle If given, only the bundle's schemas will
+     * @param bool $projectOnly If given, only the project schemas will
      *                                be returned.
      *
      * @return array A list of schemas.
      */
-    protected function getFinalSchemas(KernelInterface $kernel, BundleInterface $bundle = null)
+    protected function getFinalSchemas(KernelInterface $kernel, $projectOnly = false)
     {
-        if (null !== $bundle) {
-            return $this->getSchemaLocator()->locateFromBundle($bundle);
+        if (true === $projectOnly) {
+            return $this->getSchemaLocator()->locateFromProject($kernel);
         }
 
-        return $this->getSchemaLocator()->locateFromBundlesAndConfiguration($kernel->getBundles());
+        return $this->getSchemaLocator()->locateFromProjectAndConfiguration($kernel);
     }
 
     /**

--- a/DataCollector/PropelDataCollector.php
+++ b/DataCollector/PropelDataCollector.php
@@ -105,4 +105,12 @@ class PropelDataCollector extends DataCollector
     {
         return count($this->logger->getQueries());
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function reset()
+    {
+        // TODO: Implement reset() method.
+    }
 }

--- a/DataCollector/PropelDataCollector.php
+++ b/DataCollector/PropelDataCollector.php
@@ -1,12 +1,11 @@
 <?php
 
-/*
- * This file is part of the Symfony package.
- *
- * (c) Fabien Potencier <fabien@symfony.com>
- *
+/**
+ * This file is part of the PropelBundle package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
+ *
+ * @license    MIT License
  */
 
 namespace Propel\Bundle\PropelBundle\DataCollector;
@@ -104,5 +103,10 @@ class PropelDataCollector extends DataCollector
     private function countQueries()
     {
         return count($this->logger->getQueries());
+    }
+
+    public function reset()
+    {
+        // TODO: Implement reset() method.
     }
 }

--- a/DataFixtures/Dumper/YamlDataDumper.php
+++ b/DataFixtures/Dumper/YamlDataDumper.php
@@ -28,7 +28,6 @@ class YamlDataDumper extends AbstractDataDumper
             $data,
             $inline = 3,
             $indent = 4,
-            $exceptionOnInvalidType = false,
             $objectSupport = true
         );
     }

--- a/DataFixtures/Dumper/YamlDataDumper.php
+++ b/DataFixtures/Dumper/YamlDataDumper.php
@@ -28,8 +28,7 @@ class YamlDataDumper extends AbstractDataDumper
             $data,
             $inline = 3,
             $indent = 4,
-            $exceptionOnInvalidType = false,
-            $objectSupport = true
+            Yaml::DUMP_OBJECT
         );
     }
 }

--- a/DependencyInjection/PropelExtension.php
+++ b/DependencyInjection/PropelExtension.php
@@ -53,6 +53,7 @@ class PropelExtension extends Extension
             $loader->load('propel.xml');
             $loader->load('converters.xml');
             $loader->load('security.xml');
+            $loader->load('console.xml');
         }
     }
 

--- a/README.markdown
+++ b/README.markdown
@@ -14,7 +14,7 @@ As `Propel2` will be released in the near future, we are migrating the branching
 * The `1.2` branch contains Propel *1.6* integration for Symfony *2.2* (*currently master branch*).
 * The `2.0` branch contains `Propel2` integration for Symfony *2.5-2.8*.
 * The `3.0` branch contains `Propel2` integration for Symfony *2.8-3.x*.
-* The `4.0` branch contains `Propel2` integration for Symfony *4.x*.
+* The `4.0` branch contains `Propel2` integration for Symfony *3.4-4.x*.
 
 ## Features
 

--- a/README.markdown
+++ b/README.markdown
@@ -1,7 +1,7 @@
 PropelBundle
 ============
 
-[![Build Status](https://travis-ci.org/propelorm/PropelBundle.svg?branch=3.0)](https://travis-ci.org/propelorm/PropelBundle)
+[![Build Status](https://travis-ci.org/propelorm/PropelBundle.svg?branch=4.0)](https://travis-ci.org/propelorm/PropelBundle)
 
 This is the official implementation of [Propel](http://www.propelorm.org/) in Symfony.
 
@@ -14,6 +14,7 @@ As `Propel2` will be released in the near future, we are migrating the branching
 * The `1.2` branch contains Propel *1.6* integration for Symfony *2.2* (*currently master branch*).
 * The `2.0` branch contains `Propel2` integration for Symfony *2.5-2.8*.
 * The `3.0` branch contains `Propel2` integration for Symfony *2.8-3.x*.
+* The `4.0` branch contains `Propel2` integration for Symfony *4.x*.
 
 ## Features
 

--- a/Resources/config/console.xml
+++ b/Resources/config/console.xml
@@ -4,7 +4,6 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <defaults public="false" />
         <service id="propel_bundle_propel.command.acl_init_command" class="Propel\Bundle\PropelBundle\Command\AclInitCommand">
             <tag name="console.command" command="propel:acl:init" />
         </service>

--- a/Resources/config/console.xml
+++ b/Resources/config/console.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <defaults public="false" />
+        <service id="propel_bundle_propel.command.acl_init_command" class="Propel\Bundle\PropelBundle\Command\AclInitCommand">
+            <tag name="console.command" command="propel:acl:init" />
+        </service>
+        <service id="propel_bundle_propel.command.build_command" class="Propel\Bundle\PropelBundle\Command\BuildCommand">
+            <tag name="console.command" command="propel:build" />
+        </service>
+        <service id="propel_bundle_propel.command.database_create_command" class="Propel\Bundle\PropelBundle\Command\DatabaseCreateCommand">
+            <tag name="console.command" command="propel:database:create" />
+        </service>
+        <service class="Propel\Bundle\PropelBundle\Command\DatabaseDropCommand"
+                 id="propel_bundle_propel.command.database_drop_command">
+            <tag name="console.command" command="propel:database:drop"/>
+        </service>
+        <service class="Propel\Bundle\PropelBundle\Command\DatabaseReverseCommand"
+                 id="propel_bundle_propel.command.database_reverse_command">
+            <tag name="console.command" command="propel:database:reverse"/>
+        </service>
+        <service class="Propel\Bundle\PropelBundle\Command\FixturesDumpCommand"
+                 id="propel_bundle_propel.command.fixtures_dump_command">
+            <tag name="console.command" command="propel:fixtures:dump"/>
+        </service>
+        <service class="Propel\Bundle\PropelBundle\Command\FixturesLoadCommand"
+                 id="propel_bundle_propel.command.fixtures_load_command">
+            <tag name="console.command" command="propel:fixtures:load"/>
+        </service>
+        <service class="Propel\Bundle\PropelBundle\Command\FormGenerateCommand"
+                 id="propel_bundle_propel.command.form_generate_command">
+            <tag name="console.command" command="propel:form:generate"/>
+        </service>
+        <service class="Propel\Bundle\PropelBundle\Command\GraphvizGenerateCommand"
+                 id="propel_bundle_propel.command.graphviz_generate_command">
+            <tag name="console.command" command="propel:graphviz:generate"/>
+        </service>
+        <service class="Propel\Bundle\PropelBundle\Command\MigrationDiffCommand"
+                 id="propel_bundle_propel.command.migration_diff_command">
+            <tag name="console.command" command="propel:migration:diff"/>
+        </service>
+        <service class="Propel\Bundle\PropelBundle\Command\MigrationDownCommand"
+                 id="propel_bundle_propel.command.migration_down_command">
+            <tag name="console.command" command="propel:migration:down"/>
+        </service>
+        <service class="Propel\Bundle\PropelBundle\Command\MigrationMigrateCommand"
+                 id="propel_bundle_propel.command.migration_migrate_command">
+            <tag name="console.command" command="propel:migration:migrate"/>
+        </service>
+        <service class="Propel\Bundle\PropelBundle\Command\MigrationStatusCommand"
+                 id="propel_bundle_propel.command.migration_status_command">
+            <tag name="console.command" command="propel:migration:status"/>
+        </service>
+        <service class="Propel\Bundle\PropelBundle\Command\MigrationUpCommand"
+                 id="propel_bundle_propel.command.migration_up_command">
+            <tag name="console.command" command="propel:migration:up"/>
+        </service>
+        <service class="Propel\Bundle\PropelBundle\Command\ModelBuildCommand"
+                 id="propel_bundle_propel.command.model_build_command">
+            <tag name="console.command" command="propel:model:build"/>
+        </service>
+        <service class="Propel\Bundle\PropelBundle\Command\SqlBuildCommand"
+                 id="propel_bundle_propel.command.sql_build_command">
+            <tag name="console.command" command="propel:sql:build"/>
+        </service>
+        <service class="Propel\Bundle\PropelBundle\Command\SqlInsertCommand"
+                 id="propel_bundle_propel.command.sql_insert_command">
+            <tag name="console.command" command="propel:sql:insert"/>
+        </service>
+        <service class="Propel\Bundle\PropelBundle\Command\TableDropCommand"
+                 id="propel_bundle_propel.command.table_drop_command">
+            <tag name="console.command" command="propel:table:drop"/>
+        </service>
+    </services>
+
+</container>

--- a/Resources/config/propel.xml
+++ b/Resources/config/propel.xml
@@ -19,12 +19,12 @@
     </parameters>
 
     <services>
-        <service id="propel.schema_locator" class="%propel.schema_locator.class%">
+        <service id="propel.schema_locator" class="%propel.schema_locator.class%" public="true">
             <argument type="service" id="file_locator" />
             <argument>%propel.configuration%</argument>
         </service>
 
-        <service id="propel.logger" class="%propel.logger.class%">
+        <service id="propel.logger" class="%propel.logger.class%" public="true">
             <tag name="monolog.logger" channel="propel" />
             <argument type="service" id="logger" on-invalid="null" />
             <argument type="service" id="debug.stopwatch" on-invalid="null" />
@@ -35,30 +35,30 @@
             <tag name="data_collector" template="@Propel/Collector/propel" id="propel" />
         </service>
 
-        <service id="propel.twig.extension.syntax" class="%propel.twig.extension.syntax.class%">
+        <service id="propel.twig.extension.syntax" class="%propel.twig.extension.syntax.class%" public="true">
             <tag name="twig.extension" />
         </service>
 
-        <service id="form.type_guesser.propel" class="%form.type_guesser.propel.class%">
+        <service id="form.type_guesser.propel" class="%form.type_guesser.propel.class%" public="true">
             <tag name="form.type_guesser" />
         </service>
 
-        <service id="propel.form.type.model" class="%propel.form.type.model.class%">
+        <service id="propel.form.type.model" class="%propel.form.type.model.class%" public="true">
             <tag name="form.type" alias="model" />
         </service>
 
-        <service id="propel.dumper.yaml" class="%propel.dumper.yaml.class%">
+        <service id="propel.dumper.yaml" class="%propel.dumper.yaml.class%" public="true">
             <argument>%kernel.root_dir%</argument>
             <argument>%propel.configuration%</argument>
         </service>
 
-        <service id="propel.loader.yaml" class="%propel.loader.yaml.class%">
+        <service id="propel.loader.yaml" class="%propel.loader.yaml.class%" public="true">
             <argument>%kernel.root_dir%</argument>
             <argument>%propel.configuration%</argument>
             <argument type="service" id="faker.generator" on-invalid="null" />
         </service>
 
-        <service id="propel.loader.xml" class="%propel.loader.xml.class%">
+        <service id="propel.loader.xml" class="%propel.loader.xml.class%" public="true">
             <argument>%kernel.root_dir%</argument>
             <argument>%propel.configuration%</argument>
         </service>

--- a/Resources/config/propel.xml
+++ b/Resources/config/propel.xml
@@ -19,12 +19,12 @@
     </parameters>
 
     <services>
-        <service id="propel.schema_locator" class="%propel.schema_locator.class%">
+        <service id="propel.schema_locator" class="%propel.schema_locator.class%" public="true">
             <argument type="service" id="file_locator" />
             <argument>%propel.configuration%</argument>
         </service>
 
-        <service id="propel.logger" class="%propel.logger.class%">
+        <service id="propel.logger" class="%propel.logger.class%" public="true">
             <tag name="monolog.logger" channel="propel" />
             <argument type="service" id="logger" on-invalid="null" />
             <argument type="service" id="debug.stopwatch" on-invalid="null" />
@@ -62,5 +62,7 @@
             <argument>%kernel.root_dir%</argument>
             <argument>%propel.configuration%</argument>
         </service>
+
+
     </services>
 </container>

--- a/Resources/config/propel.xml
+++ b/Resources/config/propel.xml
@@ -35,30 +35,30 @@
             <tag name="data_collector" template="@Propel/Collector/propel" id="propel" />
         </service>
 
-        <service id="propel.twig.extension.syntax" class="%propel.twig.extension.syntax.class%" public="true">
+        <service id="propel.twig.extension.syntax" class="%propel.twig.extension.syntax.class%">
             <tag name="twig.extension" />
         </service>
 
-        <service id="form.type_guesser.propel" class="%form.type_guesser.propel.class%" public="true">
+        <service id="form.type_guesser.propel" class="%form.type_guesser.propel.class%">
             <tag name="form.type_guesser" />
         </service>
 
-        <service id="propel.form.type.model" class="%propel.form.type.model.class%" public="true">
+        <service id="propel.form.type.model" class="%propel.form.type.model.class%">
             <tag name="form.type" alias="model" />
         </service>
 
-        <service id="propel.dumper.yaml" class="%propel.dumper.yaml.class%" public="true">
+        <service id="propel.dumper.yaml" class="%propel.dumper.yaml.class%">
             <argument>%kernel.root_dir%</argument>
             <argument>%propel.configuration%</argument>
         </service>
 
-        <service id="propel.loader.yaml" class="%propel.loader.yaml.class%" public="true">
+        <service id="propel.loader.yaml" class="%propel.loader.yaml.class%">
             <argument>%kernel.root_dir%</argument>
             <argument>%propel.configuration%</argument>
-            <argument type="service" id="faker.generator" on-invalid="null" public="true"/>
+            <argument type="service" id="faker.generator" on-invalid="null" />
         </service>
 
-        <service id="propel.loader.xml" class="%propel.loader.xml.class%" public="true">
+        <service id="propel.loader.xml" class="%propel.loader.xml.class%">
             <argument>%kernel.root_dir%</argument>
             <argument>%propel.configuration%</argument>
         </service>

--- a/Resources/config/propel.xml
+++ b/Resources/config/propel.xml
@@ -19,12 +19,12 @@
     </parameters>
 
     <services>
-        <service id="propel.schema_locator" class="%propel.schema_locator.class%">
+        <service id="propel.schema_locator" class="%propel.schema_locator.class%" public="true">
             <argument type="service" id="file_locator" />
             <argument>%propel.configuration%</argument>
         </service>
 
-        <service id="propel.logger" class="%propel.logger.class%">
+        <service id="propel.logger" class="%propel.logger.class%" public="true">
             <tag name="monolog.logger" channel="propel" />
             <argument type="service" id="logger" on-invalid="null" />
             <argument type="service" id="debug.stopwatch" on-invalid="null" />
@@ -35,30 +35,30 @@
             <tag name="data_collector" template="@Propel/Collector/propel" id="propel" />
         </service>
 
-        <service id="propel.twig.extension.syntax" class="%propel.twig.extension.syntax.class%">
+        <service id="propel.twig.extension.syntax" class="%propel.twig.extension.syntax.class%" public="true">
             <tag name="twig.extension" />
         </service>
 
-        <service id="form.type_guesser.propel" class="%form.type_guesser.propel.class%">
+        <service id="form.type_guesser.propel" class="%form.type_guesser.propel.class%" public="true">
             <tag name="form.type_guesser" />
         </service>
 
-        <service id="propel.form.type.model" class="%propel.form.type.model.class%">
+        <service id="propel.form.type.model" class="%propel.form.type.model.class%" public="true">
             <tag name="form.type" alias="model" />
         </service>
 
-        <service id="propel.dumper.yaml" class="%propel.dumper.yaml.class%">
+        <service id="propel.dumper.yaml" class="%propel.dumper.yaml.class%" public="true">
             <argument>%kernel.root_dir%</argument>
             <argument>%propel.configuration%</argument>
         </service>
 
-        <service id="propel.loader.yaml" class="%propel.loader.yaml.class%">
+        <service id="propel.loader.yaml" class="%propel.loader.yaml.class%" public="true">
             <argument>%kernel.root_dir%</argument>
             <argument>%propel.configuration%</argument>
-            <argument type="service" id="faker.generator" on-invalid="null" />
+            <argument type="service" id="faker.generator" on-invalid="null" public="true"/>
         </service>
 
-        <service id="propel.loader.xml" class="%propel.loader.xml.class%">
+        <service id="propel.loader.xml" class="%propel.loader.xml.class%" public="true">
             <argument>%kernel.root_dir%</argument>
             <argument>%propel.configuration%</argument>
         </service>

--- a/Service/SchemaLocator.php
+++ b/Service/SchemaLocator.php
@@ -10,81 +10,71 @@
 
 namespace Propel\Bundle\PropelBundle\Service;
 
-use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\Finder\Finder;
-use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 class SchemaLocator
 {
-    protected $fileLocator;
+    /**
+     * @var array Configuration array
+     */
     protected $configuration;
 
-    public function __construct(FileLocatorInterface $fileLocator, array $configuration)
+    public function __construct(array $configuration)
     {
-        $this->fileLocator = $fileLocator;
         $this->configuration = $configuration;
     }
 
-    public function locateFromBundlesAndConfiguration(array $bundles)
+    /**
+     * Locate the schema files from the project default directory (`/schema`) of from the
+     * directory taken from the configuration.
+     *
+     * @param KernelInterface $kernel
+     *
+     * @return array
+     */
+    public function locateFromProjectAndConfiguration(KernelInterface $kernel)
     {
-        $schemas = $this->locateFromBundles($bundles);
+        $projectSchemas = $this->locateFromProject($kernel);
+        $confSchemas = $this->locateFromDir($this->configuration['paths']['schemaDir']);
 
-        $path = $this->configuration['paths']['schemaDir'].'/schema.xml';
-        if (file_exists($path)) {
-            $schema = new \SplFileInfo($path);
-            $schemas[(string) $schema] = array(null, $schema);
-        }
-
-        return $schemas;
-    }
-
-    public function locateFromBundles(array $bundles)
-    {
-        $schemas = array();
-        foreach ($bundles as $bundle) {
-            $schemas = array_merge($schemas, $this->locateFromBundle($bundle));
-        }
-
-        return $schemas;
+        return array_merge($projectSchemas, $confSchemas);
     }
 
     /**
-     * @param \Symfony\Component\HttpKernel\Bundle\BundleInterface
+     * Locate the schemas from the project directory.
+     *
+     * @param KernelInterface $kernel
+     *
+     * @return array
      */
-    public function locateFromBundle(BundleInterface $bundle)
+    public function locateFromProject(KernelInterface $kernel)
+    {
+        return $this->locateFromDir($kernel->getProjectDir().'/schema');
+    }
+
+    /**
+     * Locate all the schema files into a given directory.
+     *
+     * @param string $dir The directory to search in
+     *
+     * @return array
+     */
+    private function locateFromDir($dir = '')
     {
         $finalSchemas = array();
 
-        if (is_dir($dir = $bundle->getPath().'/Resources/config')) {
+        if (is_dir($dir)) {
             $finder  = new Finder();
             $schemas = $finder->files()->name('*schema.xml')->followLinks()->in($dir);
 
             if (iterator_count($schemas)) {
                 foreach ($schemas as $schema) {
-                    $logicalName = $this->transformToLogicalName($schema, $bundle);
-                    $finalSchema = new \SplFileInfo($this->fileLocator->locate($logicalName));
-
-                    $finalSchemas[(string) $finalSchema] = array($bundle, $finalSchema);
+                    $finalSchemas[(string) $schema] = $schema;
                 }
             }
         }
 
         return $finalSchemas;
-    }
-
-    /**
-     * @param  \SplFileInfo    $schema
-     * @param  BundleInterface $bundle
-     * @return string
-     */
-    protected function transformToLogicalName(\SplFileInfo $schema, BundleInterface $bundle)
-    {
-        $schemaPath = str_replace(
-            $bundle->getPath(). DIRECTORY_SEPARATOR . 'Resources' . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR,
-            '',
-            $schema->getRealPath()
-        );
-
-        return sprintf('@%s/Resources/config/%s', $bundle->getName(), $schemaPath);
     }
 }

--- a/Service/SchemaLocator.php
+++ b/Service/SchemaLocator.php
@@ -10,71 +10,81 @@
 
 namespace Propel\Bundle\PropelBundle\Service;
 
+use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\Finder\Finder;
-use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 
 class SchemaLocator
 {
-    /**
-     * @var array Configuration array
-     */
+    protected $fileLocator;
     protected $configuration;
 
-    public function __construct(array $configuration)
+    public function __construct(FileLocatorInterface $fileLocator, array $configuration)
     {
+        $this->fileLocator = $fileLocator;
         $this->configuration = $configuration;
     }
 
-    /**
-     * Locate the schema files from the project default directory (`/schema`) of from the
-     * directory taken from the configuration.
-     *
-     * @param KernelInterface $kernel
-     *
-     * @return array
-     */
-    public function locateFromProjectAndConfiguration(KernelInterface $kernel)
+    public function locateFromBundlesAndConfiguration(array $bundles)
     {
-        $projectSchemas = $this->locateFromProject($kernel);
-        $confSchemas = $this->locateFromDir($this->configuration['paths']['schemaDir']);
+        $schemas = $this->locateFromBundles($bundles);
 
-        return array_merge($projectSchemas, $confSchemas);
+        $path = $this->configuration['paths']['schemaDir'].'/schema.xml';
+        if (file_exists($path)) {
+            $schema = new \SplFileInfo($path);
+            $schemas[(string) $schema] = array(null, $schema);
+        }
+
+        return $schemas;
+    }
+
+    public function locateFromBundles(array $bundles)
+    {
+        $schemas = array();
+        foreach ($bundles as $bundle) {
+            $schemas = array_merge($schemas, $this->locateFromBundle($bundle));
+        }
+
+        return $schemas;
     }
 
     /**
-     * Locate the schemas from the project directory.
-     *
-     * @param KernelInterface $kernel
-     *
-     * @return array
+     * @param \Symfony\Component\HttpKernel\Bundle\BundleInterface
      */
-    public function locateFromProject(KernelInterface $kernel)
-    {
-        return $this->locateFromDir($kernel->getProjectDir().'/schema');
-    }
-
-    /**
-     * Locate all the schema files into a given directory.
-     *
-     * @param string $dir The directory to search in
-     *
-     * @return array
-     */
-    private function locateFromDir($dir = '')
+    public function locateFromBundle(BundleInterface $bundle)
     {
         $finalSchemas = array();
 
-        if (is_dir($dir)) {
+        if (is_dir($dir = $bundle->getPath().'/Resources/config')) {
             $finder  = new Finder();
             $schemas = $finder->files()->name('*schema.xml')->followLinks()->in($dir);
 
             if (iterator_count($schemas)) {
                 foreach ($schemas as $schema) {
-                    $finalSchemas[(string) $schema] = $schema;
+                    $logicalName = $this->transformToLogicalName($schema, $bundle);
+                    $finalSchema = new \SplFileInfo($this->fileLocator->locate($logicalName));
+
+                    $finalSchemas[(string) $finalSchema] = array($bundle, $finalSchema);
                 }
             }
         }
 
         return $finalSchemas;
+    }
+
+    /**
+     * @param  \SplFileInfo    $schema
+     * @param  BundleInterface $bundle
+     * @return string
+     */
+    protected function transformToLogicalName(\SplFileInfo $schema, BundleInterface $bundle)
+    {
+        $schemaPath = str_replace(
+            $bundle->getPath(). DIRECTORY_SEPARATOR . 'Resources' . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR,
+            '',
+            $schema->getRealPath()
+        );
+
+        return sprintf('%s/Resources/config/%s', $bundle->getName(), $schemaPath);
     }
 }

--- a/Tests/DataFixtures/Dumper/YamlDataDumperTest.php
+++ b/Tests/DataFixtures/Dumper/YamlDataDumperTest.php
@@ -51,16 +51,10 @@ class YamlDataDumperTest extends TestCase
         id: '1'
         name: 'An important one'
         author_id: CoolBookAuthor_1
-        complementary_infos: !php/object:O:8:"stdClass":1:{s:15:"first_word_date";s:10:"2012-01-01";}
+        complementary_infos: !php/object 'O:8:"stdClass":1:{s:15:"first_word_date";s:10:"2012-01-01";}'
 
 YAML;
-
         $result = file_get_contents($filename);
-
-        //yaml changed the way objects are serialized in
-        // -> https://github.com/symfony/yaml/commit/d5a7902da7e5af069bb8fdcfcf029a229deb1111
-        //so we need to replace old behavior with new, to get this test working in all versions
-        $result = str_replace(' !!php/object', ' !php/object', $result);
 
         $this->assertEquals($expected, $result);
     }

--- a/Tests/DataFixtures/Dumper/YamlDataDumperTest.php
+++ b/Tests/DataFixtures/Dumper/YamlDataDumperTest.php
@@ -51,7 +51,7 @@ class YamlDataDumperTest extends TestCase
         id: '1'
         name: 'An important one'
         author_id: CoolBookAuthor_1
-        complementary_infos: !php/object:O:8:"stdClass":1:{s:15:"first_word_date";s:10:"2012-01-01";}
+        complementary_infos: !php/object 'O:8:"stdClass":1:{s:15:"first_word_date";s:10:"2012-01-01";}'
 
 YAML;
 

--- a/Tests/Fixtures/FakeBundle/FakeBundle.php
+++ b/Tests/Fixtures/FakeBundle/FakeBundle.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: drewbrown
+ * Date: 2/2/18
+ * Time: 3:32 PM
+ */
+
+namespace Propel\Bundle\PropelBundle\Tests\Fixtures\FakeBundle;
+
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class FakeBundle extends Bundle
+{
+
+}

--- a/Tests/Model/EntryQueryTest.php
+++ b/Tests/Model/EntryQueryTest.php
@@ -39,13 +39,13 @@ class EntryQueryTest extends AclTestCase
 
     public function testFindByAclIdentityInvalidSecurityIdentity()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         EntryQuery::create()->findByAclIdentity($this->getAclObjectIdentity(), array('foo'), $this->con);
     }
 
     public function testFindByAclIdentityInvalidSecurityIdentityObject()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         EntryQuery::create()->findByAclIdentity($this->getAclObjectIdentity(), array(new \stdClass()), $this->con);
     }
 

--- a/Tests/Model/EntryTest.php
+++ b/Tests/Model/EntryTest.php
@@ -24,7 +24,7 @@ class EntryTest extends AclTestCase
 {
     public function testToAclEntry()
     {
-        $acl = $this->getMock('Propel\Bundle\PropelBundle\Security\Acl\Domain\AuditableAcl', array(), array(), '', false, false);
+        $acl = $this->createMock('Propel\Bundle\PropelBundle\Security\Acl\Domain\AuditableAcl');
         $entry = $this->createModelEntry();
 
         $aclEntry = ModelEntry::toAclEntry($entry, $acl);
@@ -45,7 +45,7 @@ class EntryTest extends AclTestCase
      */
     public function testToAclEntryFieldEntry()
     {
-        $acl = $this->getMock('Propel\Bundle\PropelBundle\Security\Acl\Domain\AuditableAcl', array(), array(), '', false, false);
+        $acl = $this->createMock('Propel\Bundle\PropelBundle\Security\Acl\Domain\AuditableAcl');
         $entry = $this->createModelEntry();
         $entry->setFieldName('name');
 

--- a/Tests/Model/EntryTest.php
+++ b/Tests/Model/EntryTest.php
@@ -24,7 +24,10 @@ class EntryTest extends AclTestCase
 {
     public function testToAclEntry()
     {
-        $acl = $this->getMock('Propel\Bundle\PropelBundle\Security\Acl\Domain\AuditableAcl', array(), array(), '', false, false);
+        $acl = $this->getMockBuilder('Propel\Bundle\PropelBundle\Security\Acl\Domain\AuditableAcl')
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $entry = $this->createModelEntry();
 
         $aclEntry = ModelEntry::toAclEntry($entry, $acl);
@@ -45,7 +48,9 @@ class EntryTest extends AclTestCase
      */
     public function testToAclEntryFieldEntry()
     {
-        $acl = $this->getMock('Propel\Bundle\PropelBundle\Security\Acl\Domain\AuditableAcl', array(), array(), '', false, false);
+        $acl = $this->getMockBuilder('Propel\Bundle\PropelBundle\Security\Acl\Domain\AuditableAcl')
+            ->disableOriginalConstructor()
+            ->getMock();
         $entry = $this->createModelEntry();
         $entry->setFieldName('name');
 

--- a/Tests/Model/ObjectIdentityQueryTest.php
+++ b/Tests/Model/ObjectIdentityQueryTest.php
@@ -80,7 +80,7 @@ class ObjectIdentityQueryTest extends AclTestCase
         $result = ObjectIdentityQuery::create()->findChildren($objIdentity, $this->con);
         $this->assertCount(1, $result);
         $this->assertInstanceOf('Propel\Bundle\PropelBundle\Model\Acl\ObjectIdentity', $result->getFirst());
-        $this->assertSame($childObjIdentity, $result->getFirst());
+        $this->assertEquals($childObjIdentity, $result->getFirst());
         $this->assertSame($objIdentity, $result->getFirst()->getObjectIdentityRelatedByParentObjectIdentityId());
     }
 

--- a/Tests/Model/SecurityIdentityTest.php
+++ b/Tests/Model/SecurityIdentityTest.php
@@ -84,7 +84,7 @@ class SecurityIdentityTest extends AclTestCase
 
     public function testFromAclIdentityWithInvalid()
     {
-        $secIdentity = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $secIdentity = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
 
         $this->setExpectedException('InvalidArgumentException');
         SecurityIdentity::fromAclIdentity($secIdentity, $this->con);

--- a/Tests/Model/SecurityIdentityTest.php
+++ b/Tests/Model/SecurityIdentityTest.php
@@ -30,7 +30,7 @@ class SecurityIdentityTest extends AclTestCase
         $identity->setIdentifier('invalidIdentifier');
         $identity->setUsername(true);
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         SecurityIdentity::toAclIdentity($identity);
     }
 
@@ -40,7 +40,7 @@ class SecurityIdentityTest extends AclTestCase
         $identity->setIdentifier('invalidIdentifier');
         $identity->setUsername(false);
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         SecurityIdentity::toAclIdentity($identity);
     }
 
@@ -84,9 +84,9 @@ class SecurityIdentityTest extends AclTestCase
 
     public function testFromAclIdentityWithInvalid()
     {
-        $secIdentity = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface');
+        $secIdentity = $this->getMockBuilder('Symfony\Component\Security\Acl\Model\SecurityIdentityInterface')->getMock();
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         SecurityIdentity::fromAclIdentity($secIdentity, $this->con);
     }
 

--- a/Tests/Security/Acl/AclProviderTest.php
+++ b/Tests/Security/Acl/AclProviderTest.php
@@ -33,7 +33,7 @@ class AclProviderTest extends AclTestCase
     {
         $provider = $this->getAclProvider();
 
-        $this->setExpectedException('Symfony\Component\Security\Acl\Exception\AclNotFoundException', 'There is no ACL available for this object identity. Please create one using the MutableAclProvider.');
+        $this->expectException('Symfony\Component\Security\Acl\Exception\AclNotFoundException', 'There is no ACL available for this object identity. Please create one using the MutableAclProvider.');
         $provider->findAcl($this->getAclObjectIdentity());
     }
 
@@ -41,7 +41,7 @@ class AclProviderTest extends AclTestCase
     {
         $provider = $this->getAclProvider();
 
-        $this->setExpectedException('Symfony\Component\Security\Acl\Exception\AclNotFoundException', 'There is at least no ACL for this object identity and the given security identities. Try retrieving the ACL without security identity filter and add ACEs for the security identities.');
+        $this->expectException('Symfony\Component\Security\Acl\Exception\AclNotFoundException', 'There is at least no ACL for this object identity and the given security identities. Try retrieving the ACL without security identity filter and add ACEs for the security identities.');
         $provider->findAcl($this->getAclObjectIdentity(), array($this->getRoleSecurityIdentity()));
     }
 
@@ -74,7 +74,7 @@ class AclProviderTest extends AclTestCase
 
         $this->assertTrue($acl->isGranted(array(1, 2, 4, 8, 16, 32, 64), array($this->getRoleSecurityIdentity('ROLE_USER'))));
 
-        $this->setExpectedException('Symfony\Component\Security\Acl\Exception\NoAceFoundException');
+        $this->expectException('Symfony\Component\Security\Acl\Exception\NoAceFoundException');
         $acl->isGranted(array(128), array($this->getRoleSecurityIdentity('ROLE_USER')));
     }
 

--- a/Tests/Security/Acl/Domain/AclTest.php
+++ b/Tests/Security/Acl/Domain/AclTest.php
@@ -29,7 +29,7 @@ class AclTest extends AclTestCase
         $collection = new ObjectCollection();
         $collection->setModel('Propel\Bundle\PropelBundle\Model\Acl\AclClass');
 
-        $this->setExpectedException('Symfony\Component\Security\Acl\Exception\Exception');
+        $this->expectException('Symfony\Component\Security\Acl\Exception\Exception');
         new Acl($collection, $this->getAclObjectIdentity(), new PermissionGrantingStrategy());
     }
 
@@ -138,7 +138,7 @@ class AclTest extends AclTestCase
         $aclObj = $this->getAclObjectIdentity();
         $acl = new Acl($collection, $aclObj, new PermissionGrantingStrategy());
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         $acl->isSidLoaded('foo');
     }
 
@@ -149,7 +149,7 @@ class AclTest extends AclTestCase
 
         $acl = new Acl($collection, $this->getAclObjectIdentity(), new PermissionGrantingStrategy());
 
-        $this->setExpectedException('Symfony\Component\Security\Acl\Exception\NoAceFoundException');
+        $this->expectException('Symfony\Component\Security\Acl\Exception\NoAceFoundException');
         $acl->isGranted(array(64), array($this->getRoleSecurityIdentity()));
     }
 
@@ -167,7 +167,7 @@ class AclTest extends AclTestCase
 
         $acl = new Acl($collection, $this->getAclObjectIdentity(), new PermissionGrantingStrategy());
 
-        $this->setExpectedException('Symfony\Component\Security\Acl\Exception\NoAceFoundException');
+        $this->expectException('Symfony\Component\Security\Acl\Exception\NoAceFoundException');
         $acl->isGranted(array(64), array($this->getRoleSecurityIdentity('ROLE_USER')));
     }
 
@@ -178,7 +178,7 @@ class AclTest extends AclTestCase
 
         $acl = new Acl($collection, $this->getAclObjectIdentity(), new PermissionGrantingStrategy());
 
-        $this->setExpectedException('Symfony\Component\Security\Acl\Exception\NoAceFoundException');
+        $this->expectException('Symfony\Component\Security\Acl\Exception\NoAceFoundException');
         $acl->isFieldGranted('name', array(64), array($this->getRoleSecurityIdentity()));
     }
 

--- a/Tests/Security/Acl/Domain/AuditableAclTest.php
+++ b/Tests/Security/Acl/Domain/AuditableAclTest.php
@@ -31,7 +31,7 @@ class AuditableAclTest extends AclTestCase
 
         $acl = new AuditableAcl($collection, $this->getAclObjectIdentity(), new PermissionGrantingStrategy());
 
-        $this->setExpectedException('OutOfBoundsException');
+        $this->expectException('OutOfBoundsException');
         $acl->updateObjectAuditing(0, false, false);
     }
 
@@ -51,7 +51,7 @@ class AuditableAclTest extends AclTestCase
         $collection->append($entry);
         $acl = new AuditableAcl($collection, $this->getAclObjectIdentity(), new PermissionGrantingStrategy());
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         $acl->updateObjectFieldAuditing(0, 'foo', false, false);
     }
 
@@ -70,7 +70,7 @@ class AuditableAclTest extends AclTestCase
         $collection->append($entry);
         $acl = new AuditableAcl($collection, $this->getAclObjectIdentity(), new PermissionGrantingStrategy());
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         $acl->updateObjectAuditing(0, 'foo', 'bar');
     }
 

--- a/Tests/Security/Acl/Domain/MutableAclTest.php
+++ b/Tests/Security/Acl/Domain/MutableAclTest.php
@@ -30,7 +30,7 @@ class MutableAclTest extends AclTestCase
         $collection = new ObjectCollection();
         $collection->setModel('Propel\Bundle\PropelBundle\Model\Acl\AclClass');
 
-        $this->setExpectedException('Symfony\Component\Security\Acl\Exception\Exception');
+        $this->expectException('Symfony\Component\Security\Acl\Exception\Exception');
         new MutableAcl($collection, $this->getAclObjectIdentity(), new PermissionGrantingStrategy(), array(), null, false, $this->con);
     }
 
@@ -68,14 +68,14 @@ class MutableAclTest extends AclTestCase
     public function testInsertAceInvalidMask()
     {
         $acl = $this->createEmptyAcl();
-        $this->setExpectedException('InvalidArgumentException', 'The given mask is not valid. Please provide an integer.');
+        $this->expectException('InvalidArgumentException', 'The given mask is not valid. Please provide an integer.');
         $acl->insertClassAce($this->getRoleSecurityIdentity(), 'foo');
     }
 
     public function testInsertAceOutofBounds()
     {
         $acl = $this->createEmptyAcl();
-        $this->setExpectedException('OutOfBoundsException', 'The index must be in the interval [0, 0].');
+        $this->expectException('OutOfBoundsException', 'The index must be in the interval [0, 0].');
         $acl->insertClassAce($this->getRoleSecurityIdentity(), 64, 1);
     }
 
@@ -120,7 +120,7 @@ class MutableAclTest extends AclTestCase
     public function testUpdateAceInvalidIndex()
     {
         $acl = $this->createEmptyAcl();
-        $this->setExpectedException('OutOfBoundsException');
+        $this->expectException('OutOfBoundsException');
         $acl->updateClassAce(0, 64);
     }
 
@@ -132,7 +132,7 @@ class MutableAclTest extends AclTestCase
         $acl = $this->createEmptyAcl();
         $acl->insertClassAce($this->getRoleSecurityIdentity(), 64);
 
-        $this->setExpectedException('InvalidArgumentException', 'The given field "name" does not exist.');
+        $this->expectException('InvalidArgumentException', 'The given field "name" does not exist.');
         $acl->updateClassFieldAce(0, 'name', 128);
     }
 

--- a/Tests/Security/Acl/MutableAclProviderTest.php
+++ b/Tests/Security/Acl/MutableAclProviderTest.php
@@ -109,7 +109,7 @@ class MutableAclProviderTest extends AclTestCase
 
     public function testUpdateAclInvalidAcl()
     {
-        $acl = $this->getMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
+        $acl = $this->createMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
 
         $this->setExpectedException('InvalidArgumentException');
         $this->getAclProvider()->updateAcl($acl);

--- a/Tests/Security/Acl/MutableAclProviderTest.php
+++ b/Tests/Security/Acl/MutableAclProviderTest.php
@@ -83,7 +83,7 @@ class MutableAclProviderTest extends AclTestCase
         $acl->insertObjectAce($this->getRoleSecurityIdentity(), 64);
         $this->getAclProvider()->updateAcl($acl);
 
-        $this->setExpectedException('Symfony\Component\Security\Acl\Exception\AclAlreadyExistsException');
+        $this->expectException('Symfony\Component\Security\Acl\Exception\AclAlreadyExistsException');
         $this->getAclProvider()->createAcl($this->getAclObjectIdentity(1));
     }
 
@@ -109,9 +109,9 @@ class MutableAclProviderTest extends AclTestCase
 
     public function testUpdateAclInvalidAcl()
     {
-        $acl = $this->getMock('Symfony\Component\Security\Acl\Model\MutableAclInterface');
+        $acl = $this->getMockBuilder('Symfony\Component\Security\Acl\Model\MutableAclInterface')->getMock();
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         $this->getAclProvider()->updateAcl($acl);
     }
 

--- a/Tests/Service/SchemaLocatorTest.php
+++ b/Tests/Service/SchemaLocatorTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * This file is part of the PropelBundle package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
+namespace Propel\Bundle\PropelBundle\Tests\Service;
+
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
+use Propel\Bundle\PropelBundle\Service\SchemaLocator;
+use Propel\Bundle\PropelBundle\Tests\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\Kernel;
+
+class SchemaLocatorTest extends TestCase
+{
+    /**
+     * @var Kernel
+     */
+    private $kernelMock;
+
+    /**
+     * @var vfsStreamDirectory
+     */
+    private $root;
+
+    /**
+     * @var array
+     */
+    private $configuration;
+
+    public function setUp()
+    {
+        $pathStructure = [
+                'schema' => [
+                    'first.schema.xml' => 'First database schema',
+                    'second.schema.xml' => 'Second database schema'
+                ],
+                'configuration' => [
+                    'directory' => [
+                        'schema.xml' => 'Schema from configuration'
+                    ]
+                ]
+        ];
+        $this->root = vfsStream::setup('projectDir');
+        vfsStream::create($pathStructure);
+
+        $this->kernelMock = $this->getMockBuilder(Kernel::class)->disableOriginalConstructor()-> getMock();
+        $this->kernelMock->method('getProjectDir')->willReturn($this->root->url());
+
+        $this->configuration['paths']['schemaDir'] = vfsStream::url('projectDir/configuration/directory');
+    }
+
+    public function testLocateFromProject()
+    {
+        $locator = new SchemaLocator($this->configuration);
+        $files = $locator->locateFromProject($this->kernelMock);
+
+        $this->assertCount(2, $files);
+        $this->assertTrue(isset($files['vfs://projectDir/schema/first.schema.xml']));
+        $this->assertEquals('first.schema.xml', $files['vfs://projectDir/schema/first.schema.xml']->getFileName());
+        $this->assertTrue(isset($files['vfs://projectDir/schema/second.schema.xml']));
+        $this->assertEquals('second.schema.xml', $files['vfs://projectDir/schema/second.schema.xml']->getFileName());
+    }
+
+    public function testLocateFromProjectAndConfiguration()
+    {
+        $locator = new SchemaLocator($this->configuration);
+        $files = $locator->locateFromProjectAndConfiguration($this->kernelMock);
+
+        $this->assertCount(3, $files);
+        $this->assertTrue(isset($files['vfs://projectDir/schema/first.schema.xml']));
+        $this->assertEquals('first.schema.xml', $files['vfs://projectDir/schema/first.schema.xml']->getFileName());
+        $this->assertTrue(isset($files['vfs://projectDir/schema/second.schema.xml']));
+        $this->assertEquals('second.schema.xml', $files['vfs://projectDir/schema/second.schema.xml']->getFileName());
+        $this->assertTrue(isset($files['vfs://projectDir/configuration/directory/schema.xml']));
+        $this->assertEquals('schema.xml', $files['vfs://projectDir/configuration/directory/schema.xml']->getFileName());
+    }
+}

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -10,6 +10,7 @@
 
 namespace Propel\Bundle\PropelBundle\Tests;
 
+use PHPUnit\Framework\TestCase as BaseTestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
@@ -17,7 +18,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 /**
  * TestCase
  */
-class TestCase extends \PHPUnit_Framework_TestCase
+class TestCase extends BaseTestCase
 {
     public function getContainer()
     {

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,7 +1,0 @@
-<?php
-
-require_once __DIR__ . '/../vendor/autoload.php';
-
-if(!class_exists('Symfony\\Component\\Form\\Test\\TypeTestCase')) {
-    class_alias('Symfony\\Component\\Form\\Tests\\Extension\\Core\\Type\\TypeTestCase', 'Symfony\\Component\\Form\\Test\\TypeTestCase');
-}

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
 
     "require": {
-        "propel/propel": "dev-master",
+        "propel/propel": "~2.0@dev",
         "symfony/console": "^2.8|^3.0|^4.0",
         "symfony/dependency-injection": "^2.8|^3.0|^4.0",
         "symfony/framework-bundle": "^2.8|^3.0|^4.0",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "propel/propel-bundle",
-    "description": "Integration of Propel in Symfony2",
+    "description": "Integration of Propel in Symfony 4.0",
     "keywords": ["propel", "orm", "persistence"],
     "type": "symfony-bundle",
     "license": "MIT",
@@ -8,12 +8,10 @@
         "name": "William Durand",
         "email": "william.durand1@gmail.com"
     }],
-
     "autoload": {
         "psr-4": { "Propel\\Bundle\\PropelBundle\\": "" },
         "exclude-from-classmap": [ "Tests/" ]
     },
-
     "require": {
         "propel/propel": "~2.0@dev",
         "symfony/console": "^2.8|^3.0|^4.0",
@@ -24,6 +22,12 @@
     "require-dev": {
         "phpunit/phpunit": "^4.8.21|^5.0.10",
         "sensio/framework-extra-bundle": "^3.0.2|^4.0",
+        "symfony/form": "^2.8|^3.0|^4.0",
         "fzaninotto/faker": "^1.5"
+    },
+    "extra": {
+        "branch-alias": {
+            "4.0": "4.0"
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,14 @@
 
     "require": {
         "propel/propel": "dev-master",
-        "symfony/console": "^2.8|^3.0",
-        "symfony/dependency-injection": "^2.8|^3.0",
-        "symfony/framework-bundle": "^2.8|^3.0",
-        "symfony/security-acl": "^2.8|^3.0"
+        "symfony/console": "^2.8|^3.0|^4.0",
+        "symfony/dependency-injection": "^2.8|^3.0|^4.0",
+        "symfony/framework-bundle": "^2.8|^3.0|^4.0",
+        "symfony/security-acl": "^2.8|^3.0|^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.21|^5.0.10",
-        "sensio/framework-extra-bundle": "^3.0.2",
+        "sensio/framework-extra-bundle": "^3.0.2|^4.0",
         "fzaninotto/faker": "^1.5"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
 
     "require": {
         "propel/propel": "dev-master",
-        "symfony/console": "^2.8|^3.0",
-        "symfony/dependency-injection": "^2.8|^3.0",
-        "symfony/framework-bundle": "^2.8|^3.0",
-        "symfony/security-acl": "^2.8|^3.0"
+        "symfony/console": "^2.8|^3.0|^4.0",
+        "symfony/dependency-injection": "^2.8|^3.0|^4.0",
+        "symfony/framework-bundle": "^2.8|^3.0|^4.0",
+        "symfony/security-acl": "^2.8|^3.0|^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.21|^5.0.10",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "propel/propel-bundle",
-    "description": "Integration of Propel in Symfony2",
+    "description": "Integration of Propel in Symfony",
     "keywords": ["propel", "orm", "persistence"],
     "type": "symfony-bundle",
     "license": "MIT",
@@ -16,14 +16,20 @@
 
     "require": {
         "propel/propel": "dev-master",
-        "symfony/console": "^2.8|^3.0",
-        "symfony/dependency-injection": "^2.8|^3.0",
-        "symfony/framework-bundle": "^2.8|^3.0",
-        "symfony/security-acl": "^2.8|^3.0"
+        "symfony/console": "^4.0",
+        "symfony/dependency-injection": "^4.0",
+        "symfony/framework-bundle": "^4.0",
+        "symfony/form": "^4.0",
+        "symfony/security": "^4.0"
+    },
+    "suggest": {
+        "symfony/security-acl": "For using acl instead of voters"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.21|^5.0.10",
-        "sensio/framework-extra-bundle": "^3.0.2",
-        "fzaninotto/faker": "^1.5"
+        "phpunit/phpunit": "^6.0",
+        "sensio/framework-extra-bundle": "^4.0",
+        "fzaninotto/faker": "^1.5",
+        "symfony/security-acl": "^3.0",
+        "mikey179/vfsStream": "^1.6"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,7 @@
   processIsolation="false"
   stopOnFailure="false"
   syntaxCheck="false"
-  bootstrap="./Tests/bootstrap.php">
+  bootstrap="vendor/autoload.php">
   <php>
     <!-- <server name="SYMFONY" value="/path/to/symfony" /> -->
   </php>


### PR DESCRIPTION
Added support for Symfony 4.0.  Updated unit tests to remove deprecated functions, and match current object serialization strings for YamlDumper