### PR TITLE
propel.configuration and propel.logger services as public

### DIFF
--- a/Resources/config/propel.xml
+++ b/Resources/config/propel.xml
@@ -17,11 +17,11 @@
     </parameters>
 
     <services>
-        <service id="propel.configuration" class="%propel.configuration.class%" />
+        <service id="propel.configuration" class="%propel.configuration.class%" public="true"/>
 
         <service id="propel.build_properties" class="%propel.build_properties.class%" />
 
-        <service id="propel.logger" class="%propel.logger.class%">
+        <service id="propel.logger" class="%propel.logger.class%" public="true">
             <tag name="monolog.logger" channel="propel" />
             <argument type="service" id="logger" on-invalid="null" />
             <argument type="service" id="debug.stopwatch" on-invalid="null" />

--- a/Tests/DataFixtures/Dumper/YamlDataDumperTest.php
+++ b/Tests/DataFixtures/Dumper/YamlDataDumperTest.php
@@ -54,6 +54,9 @@ Propel\Bundle\PropelBundle\Tests\Fixtures\DataFixtures\Loader\Book:
 YAML;
 
         $result = file_get_contents($filename);
+        if (strpos($result, '!php/object:') === FALSE) {
+            $expected = preg_replace('|!php/object:(.*?)$|', '!php/object \'$1\'', $expected);
+        }
         $this->assertEquals($expected, $result);
     }
 }


### PR DESCRIPTION
* Mark propel.configuration and propel.logger services as public to resolve Symfony 3.2 deprecation warning
* Fix YamlDataDumperTest that fails under Symfony 3.4 due to format change: https://github.com/symfony/yaml/blob/master/CHANGELOG.md#340

Fixes #481 