### PR TITLE
add reset() function to PropelDataCollector

### DIFF
--- a/DataCollector/PropelDataCollector.php
+++ b/DataCollector/PropelDataCollector.php
@@ -49,6 +49,11 @@ class PropelDataCollector extends DataCollector
         $this->propelConfiguration = $propelConfiguration;
     }
 
+    public function reset()
+    {
+        $this->logger->reset();
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/Logger/PropelLogger.php
+++ b/Logger/PropelLogger.php
@@ -54,6 +54,11 @@ class PropelLogger implements \BasicLogger
         $this->stopwatch = $stopwatch;
     }
 
+    public function reset()
+    {
+        $this->queries = array();
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/Tests/DataFixtures/Dumper/YamlDataDumperTest.php
+++ b/Tests/DataFixtures/Dumper/YamlDataDumperTest.php
@@ -54,6 +54,9 @@ Propel\Bundle\PropelBundle\Tests\Fixtures\DataFixtures\Loader\Book:
 YAML;
 
         $result = file_get_contents($filename);
+        if (strpos($result, '!php/object:') === FALSE) {
+            $expected = preg_replace('|!php/object:(.*?)$|', '!php/object \'$1\'', $expected);
+        }
         $this->assertEquals($expected, $result);
     }
 }

--- a/Tests/DataFixtures/Dumper/YamlDataDumperTest.php
+++ b/Tests/DataFixtures/Dumper/YamlDataDumperTest.php
@@ -54,7 +54,7 @@ Propel\Bundle\PropelBundle\Tests\Fixtures\DataFixtures\Loader\Book:
 YAML;
 
         $result = file_get_contents($filename);
-        if (strpos($result, '!php/object:') === FALSE) {
+        if (strpos($result, '!php/object:') === false) {
             $expected = preg_replace('|!php/object:(.*?)$|', '!php/object \'$1\'', $expected);
         }
         $this->assertEquals($expected, $result);


### PR DESCRIPTION
Resolve Symfony 3.4 deprecation warning by adding reset() function to PropelDataCollector and PropelLogger

Fixes #482 